### PR TITLE
feat: add queue/force-due endpoint to reschedule stuck Queued rows

### DIFF
--- a/src/app/api/internal/queue/force-due/route.js
+++ b/src/app/api/internal/queue/force-due/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { child } from "@/lib/logging/logger.js";
+import { handleQueueForceDueRequest } from "@/lib/domain/queue/queue-force-due-request.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const logger = child({
+  module: "api.internal.queue.force-due",
+});
+
+export async function GET(request) {
+  return handleQueueForceDueRequest(request, "GET", {
+    logger,
+    jsonResponse: NextResponse.json,
+  });
+}
+
+export async function POST(request) {
+  return handleQueueForceDueRequest(request, "POST", {
+    logger,
+    jsonResponse: NextResponse.json,
+  });
+}

--- a/src/lib/domain/queue/force-due-queued-items.js
+++ b/src/lib/domain/queue/force-due-queued-items.js
@@ -1,0 +1,318 @@
+import APP_IDS from "@/lib/config/app-ids.js";
+import { toPodioDateTimeString, toPodioDateField } from "@/lib/utils/dates.js";
+import { info, warn } from "@/lib/logging/logger.js";
+
+// Podio helpers are loaded lazily so this module can be imported in tests
+// without requiring a live axios installation (same pattern as queue-run-request.js).
+async function loadPodio(overrides = {}) {
+  if (
+    overrides.fetchAllItems &&
+    overrides.updateItem &&
+    overrides.getCategoryValue &&
+    overrides.getDateValue &&
+    overrides.getFirstAppReferenceId
+  ) {
+    return overrides;
+  }
+  const podio = await import("@/lib/providers/podio.js");
+  return {
+    fetchAllItems: overrides.fetchAllItems ?? podio.fetchAllItems,
+    updateItem: overrides.updateItem ?? podio.updateItem,
+    getCategoryValue: overrides.getCategoryValue ?? podio.getCategoryValue,
+    getDateValue: overrides.getDateValue ?? podio.getDateValue,
+    getFirstAppReferenceId:
+      overrides.getFirstAppReferenceId ?? podio.getFirstAppReferenceId,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CONSTANTS
+// ──────────────────────────────────────────────────────────────────────────────
+
+const FORCE_DUE_MAX_ROWS = 25;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// UTILITIES
+// ──────────────────────────────────────────────────────────────────────────────
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function lower(value) {
+  return clean(value).toLowerCase();
+}
+
+function toTimestamp(value) {
+  if (!value) return null;
+  const ts = new Date(value).getTime();
+  return Number.isNaN(ts) ? null : ts;
+}
+
+function mapTimezoneToIana(value) {
+  const raw = lower(value);
+
+  if (raw === "eastern" || raw === "et" || raw === "est" || raw === "edt") {
+    return "America/New_York";
+  }
+  if (raw === "central" || raw === "ct" || raw === "cst" || raw === "cdt") {
+    return "America/Chicago";
+  }
+  if (raw === "mountain" || raw === "mt" || raw === "mst" || raw === "mdt") {
+    return "America/Denver";
+  }
+  if (raw === "pacific" || raw === "pt" || raw === "pst" || raw === "pdt") {
+    return "America/Los_Angeles";
+  }
+  if (raw === "alaska") {
+    return "America/Anchorage";
+  }
+  if (raw === "hawaii") {
+    return "Pacific/Honolulu";
+  }
+
+  return "America/Chicago";
+}
+
+/**
+ * Format a Date as "YYYY-MM-DD HH:MM:SS" in the given IANA timezone.
+ * Falls back to the UTC Podio format if the timezone is invalid.
+ */
+function toPodioLocalDateTimeString(date, timezone_iana) {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone_iana,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+
+    const parts = formatter.formatToParts(date);
+    const get = (type) => parts.find((p) => p.type === type)?.value ?? "00";
+
+    const year = get("year");
+    const month = get("month");
+    const day = get("day");
+    // hour12: false may return "24" for midnight in some Node versions
+    const raw_hour = get("hour");
+    const hour = raw_hour === "24" ? "00" : raw_hour;
+    const minute = get("minute");
+    const second = get("second");
+
+    return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+  } catch {
+    // fallback: reuse the UTC Podio formatter
+    return toPodioDateTimeString(date);
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DOMAIN FUNCTION
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Force-reschedule stuck Queued rows to be due immediately.
+ *
+ * @param {object} options
+ * @param {number}  [options.limit=25]              Max rows to reschedule (hard cap 25).
+ * @param {boolean} [options.dry_run=true]          When true, no writes are made.
+ * @param {number}  [options.master_owner_id=null]  Scope to a single master owner.
+ * @param {number}  [options.older_than_minutes]    When set, only target rows that are
+ *                                                   either scheduled in the future OR
+ *                                                   overdue by more than this many minutes.
+ * @param {string}  [options.now]                   ISO timestamp override (for tests).
+ * @param {object}  [deps]                          Injectable dependencies.
+ */
+export async function forceDueQueuedItems(
+  {
+    limit = FORCE_DUE_MAX_ROWS,
+    dry_run = true,
+    master_owner_id = null,
+    older_than_minutes = null,
+    now = null,
+  } = {},
+  deps = {}
+) {
+  const podio = await loadPodio(deps);
+  const fetch_all_items = podio.fetchAllItems;
+  const update_item = podio.updateItem;
+  const get_category_value = podio.getCategoryValue;
+  const get_date_value = podio.getDateValue;
+  const get_first_app_reference_id = podio.getFirstAppReferenceId;
+  const info_log = deps.info || info;
+  const warn_log = deps.warn || warn;
+
+  const run_started_at = now || nowIso();
+  const now_ts = toTimestamp(run_started_at) ?? Date.now();
+  const now_date = new Date(now_ts);
+  const scoped_master_owner_id = Number(master_owner_id || 0) || null;
+  const effective_limit = Math.min(
+    Math.max(1, Number(limit) || FORCE_DUE_MAX_ROWS),
+    FORCE_DUE_MAX_ROWS
+  );
+  const older_than_ms =
+    older_than_minutes !== null && older_than_minutes !== undefined
+      ? Number(older_than_minutes) * 60_000
+      : null;
+
+  info_log("queue_force_due.started", {
+    limit: effective_limit,
+    dry_run,
+    master_owner_id: scoped_master_owner_id,
+    older_than_minutes: older_than_minutes ?? null,
+    run_started_at,
+  });
+
+  // ── Fetch all Queued rows ──────────────────────────────────────────────────
+
+  const queued_items = await fetch_all_items(
+    APP_IDS.send_queue,
+    { "queue-status": "Queued" },
+    {
+      page_size: Math.max(effective_limit * 4, 50),
+      sort_by: "scheduled-for-utc",
+      sort_desc: false,
+    }
+  );
+
+  info_log("queue_force_due.rows_loaded", {
+    total_rows_loaded: queued_items.length,
+    master_owner_id: scoped_master_owner_id,
+    run_started_at,
+  });
+
+  // ── Filter eligible rows ───────────────────────────────────────────────────
+
+  const eligible = [];
+
+  for (const item of queued_items) {
+    if (eligible.length >= effective_limit) break;
+
+    const item_id = item?.item_id;
+    const status = get_category_value(item, "queue-status", null);
+
+    // Must be Queued
+    if (lower(status) !== "queued") {
+      continue;
+    }
+
+    // master_owner scope filter
+    if (
+      scoped_master_owner_id &&
+      Number(get_first_app_reference_id(item, "master-owner", 0) || 0) !==
+        scoped_master_owner_id
+    ) {
+      continue;
+    }
+
+    // older_than_minutes filter
+    if (older_than_ms !== null) {
+      const scheduled_utc = get_date_value(item, "scheduled-for-utc", null);
+      const scheduled_ts = toTimestamp(scheduled_utc);
+
+      if (scheduled_ts !== null) {
+        const is_future = scheduled_ts > now_ts;
+        const is_long_overdue = scheduled_ts < now_ts - older_than_ms;
+
+        if (!is_future && !is_long_overdue) {
+          // Row is recent-past but not overdue by threshold — skip it;
+          // the normal runner should handle it.
+          continue;
+        }
+      }
+      // null scheduled_ts → no schedule set, always eligible
+    }
+
+    eligible.push(item);
+  }
+
+  // ── Build per-row action plan ──────────────────────────────────────────────
+
+  const now_utc_podio = toPodioDateField(now_date); // { start: "YYYY-MM-DD HH:MM:SS" }
+  const new_scheduled_utc = now_utc_podio?.start ?? toPodioDateTimeString(now_date);
+
+  const actions = eligible.map((item) => {
+    const timezone_label = get_category_value(item, "timezone", "Central");
+    const timezone_iana = mapTimezoneToIana(timezone_label);
+
+    return {
+      queue_item_id: item?.item_id,
+      old_scheduled_utc: get_date_value(item, "scheduled-for-utc", null),
+      new_scheduled_utc,
+      old_scheduled_local: get_date_value(item, "scheduled-for-local", null),
+      new_scheduled_local: toPodioLocalDateTimeString(now_date, timezone_iana),
+      timezone: timezone_label,
+      timezone_iana,
+      reason: "force_due_rescheduled",
+    };
+  });
+
+  // ── Mutate (only when dry_run=false) ──────────────────────────────────────
+
+  let rescheduled_count = 0;
+
+  if (!dry_run) {
+    for (const action of actions) {
+      try {
+        await update_item(action.queue_item_id, {
+          "scheduled-for-utc": now_utc_podio,
+          "scheduled-for-local": { start: action.new_scheduled_local },
+        });
+
+        rescheduled_count += 1;
+
+        info_log("queue_force_due.row_rescheduled", {
+          queue_item_id: action.queue_item_id,
+          old_scheduled_utc: action.old_scheduled_utc,
+          new_scheduled_utc: action.new_scheduled_utc,
+          old_scheduled_local: action.old_scheduled_local,
+          new_scheduled_local: action.new_scheduled_local,
+          timezone: action.timezone,
+          dry_run: false,
+        });
+      } catch (err) {
+        warn_log("queue_force_due.row_reschedule_failed", {
+          queue_item_id: action.queue_item_id,
+          error: err?.message ?? "unknown",
+          dry_run: false,
+        });
+      }
+    }
+  }
+
+  const summary = {
+    ok: true,
+    dry_run,
+    run_started_at,
+    total_rows_loaded: queued_items.length,
+    eligible_rows: eligible.length,
+    rescheduled_count: dry_run ? 0 : rescheduled_count,
+    skipped_count: queued_items.length - eligible.length,
+    master_owner_id: scoped_master_owner_id,
+    older_than_minutes: older_than_minutes ?? null,
+    first_10_candidate_item_ids: eligible.slice(0, 10).map((i) => i?.item_id),
+    first_10_actions: actions.slice(0, 10),
+  };
+
+  info_log("queue_force_due.completed", {
+    dry_run,
+    total_rows_loaded: queued_items.length,
+    eligible_rows: eligible.length,
+    rescheduled_count: summary.rescheduled_count,
+    skipped_count: summary.skipped_count,
+    master_owner_id: scoped_master_owner_id,
+    run_started_at,
+  });
+
+  return summary;
+}
+
+export default forceDueQueuedItems;

--- a/src/lib/domain/queue/queue-force-due-request.js
+++ b/src/lib/domain/queue/queue-force-due-request.js
@@ -1,0 +1,138 @@
+import {
+  getRolloutControls,
+  resolveMutationDryRun,
+  resolveScopedId,
+} from "@/lib/config/rollout-controls.js";
+
+const FORCE_DUE_MAX_ROWS = 25;
+
+function asBoolean(value, fallback = false) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes"].includes(normalized)) return true;
+    if (["false", "0", "no"].includes(normalized)) return false;
+  }
+  return fallback;
+}
+
+function asNumber(value, fallback = null) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function statusForResult(result) {
+  return result?.ok === false ? 400 : 200;
+}
+
+export async function handleQueueForceDueRequest(request, method, deps = {}) {
+  const require_cron_auth =
+    deps.requireCronAuth ||
+    (await import("@/lib/security/cron-auth.js")).requireCronAuth;
+  const force_due_queued_items =
+    deps.forceDueQueuedItems ||
+    (await import("@/lib/domain/queue/force-due-queued-items.js"))
+      .forceDueQueuedItems;
+  const route_logger = deps.logger;
+  const json_response =
+    deps.jsonResponse ||
+    ((body, init) => Response.json(body, { status: init?.status }));
+
+  route_logger?.info?.("queue_force_due.route_enter", { method });
+
+  try {
+    const auth = require_cron_auth(request, route_logger);
+    if (!auth.authorized) return auth.response;
+
+    const { searchParams } = new URL(request.url);
+    const body =
+      method === "POST"
+        ? await request.json().catch(() => ({}))
+        : null;
+
+    const rollout = getRolloutControls();
+    const master_owner_scope = resolveScopedId({
+      requested_id: asNumber(
+        method === "POST"
+          ? body?.master_owner_id
+          : searchParams.get("master_owner_id"),
+        null
+      ),
+      safe_id: rollout.single_master_owner_id,
+      resource: "master_owner",
+    });
+
+    if (!master_owner_scope.ok) {
+      return json_response(
+        { ok: false, error: master_owner_scope.reason },
+        { status: 400 }
+      );
+    }
+
+    const limit = Math.min(
+      asNumber(
+        method === "POST" ? body?.limit : searchParams.get("limit"),
+        FORCE_DUE_MAX_ROWS
+      ) ?? FORCE_DUE_MAX_ROWS,
+      FORCE_DUE_MAX_ROWS
+    );
+
+    // Default dry_run=true for this recovery tool — must be explicitly opt-out
+    const dry_run_resolution = resolveMutationDryRun({
+      requested_dry_run: asBoolean(
+        method === "POST" ? body?.dry_run : searchParams.get("dry_run"),
+        true
+      ),
+    });
+
+    const older_than_minutes = asNumber(
+      method === "POST"
+        ? body?.older_than_minutes
+        : searchParams.get("older_than_minutes"),
+      null
+    );
+
+    route_logger?.info?.("queue_force_due.requested", {
+      method,
+      limit,
+      dry_run: dry_run_resolution.effective_dry_run,
+      master_owner_id: master_owner_scope.effective_id,
+      older_than_minutes,
+      authenticated: auth.auth.authenticated,
+      is_vercel_cron: auth.auth.is_vercel_cron,
+    });
+
+    const result = await force_due_queued_items({
+      limit,
+      dry_run: dry_run_resolution.effective_dry_run,
+      master_owner_id: master_owner_scope.effective_id,
+      older_than_minutes,
+    });
+
+    route_logger?.info?.("queue_force_due.completed", {
+      ok: result?.ok !== false,
+      dry_run: result?.dry_run ?? null,
+      total_rows_loaded: result?.total_rows_loaded ?? null,
+      eligible_rows: result?.eligible_rows ?? null,
+      rescheduled_count: result?.rescheduled_count ?? null,
+      skipped_count: result?.skipped_count ?? null,
+      master_owner_id: result?.master_owner_id ?? null,
+    });
+
+    return json_response(
+      {
+        ok: result?.ok !== false,
+        route: "internal/queue/force-due",
+        result,
+      },
+      { status: statusForResult(result) }
+    );
+  } catch (error) {
+    route_logger?.error?.("queue_force_due.failed", { error });
+
+    return json_response(
+      { ok: false, error: "queue_force_due_failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/tests/critical/queue-force-due.test.mjs
+++ b/tests/critical/queue-force-due.test.mjs
@@ -1,0 +1,393 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { forceDueQueuedItems } from "@/lib/domain/queue/force-due-queued-items.js";
+import { handleQueueForceDueRequest } from "@/lib/domain/queue/queue-force-due-request.js";
+import {
+  appRefField,
+  categoryField,
+  createPodioItem,
+  dateField,
+} from "../helpers/test-helpers.js";
+
+// ─── podio field reader stubs (mirror the real helpers, no axios needed) ─────
+
+function getCategoryValue(item, external_id, fallback = null) {
+  const field = item?.fields?.find((f) => f.external_id === external_id);
+  const val = field?.values?.[0];
+  return val?.value?.text ?? fallback;
+}
+
+function getDateValue(item, external_id, fallback = null) {
+  const field = item?.fields?.find((f) => f.external_id === external_id);
+  const val = field?.values?.[0];
+  return val?.start ?? fallback;
+}
+
+function getFirstAppReferenceId(item, external_id, fallback = null) {
+  const field = item?.fields?.find((f) => f.external_id === external_id);
+  const val = field?.values?.[0];
+  return val?.value?.item_id ?? fallback;
+}
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+const FIXED_NOW = "2026-04-05T18:00:00.000Z";
+// Expected Podio UTC string for FIXED_NOW
+const FIXED_NOW_PODIO_UTC = "2026-04-05 18:00:00";
+// Central (CDT = UTC-5): 18:00 UTC = 13:00 CDT
+const FIXED_NOW_CENTRAL_LOCAL = "2026-04-05 13:00:00";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeQueuedItem(item_id, overrides = {}) {
+  return createPodioItem(item_id, {
+    "queue-status": categoryField(overrides["queue-status"] ?? "Queued"),
+    "scheduled-for-utc": dateField(
+      overrides["scheduled-for-utc"] ?? "2026-04-06 10:00:00"
+    ),
+    "scheduled-for-local": dateField(
+      overrides["scheduled-for-local"] ?? "2026-04-06 05:00:00"
+    ),
+    timezone: categoryField(overrides.timezone ?? "Central"),
+    "contact-window": categoryField(overrides["contact-window"] ?? "9 AM - 8 PM"),
+    "master-owner": appRefField(overrides["master-owner"] ?? 999),
+  });
+}
+
+function makeDeps(items = [], updates = []) {
+  return {
+    fetchAllItems: async () => items,
+    updateItem: async (item_id, payload) => {
+      updates.push({ item_id, payload });
+    },
+    getCategoryValue,
+    getDateValue,
+    getFirstAppReferenceId,
+    info: () => {},
+    warn: () => {},
+  };
+}
+
+// ─── 1. dry run returns candidates without mutating ───────────────────────────
+
+test("forceDueQueuedItems dry_run=true returns eligible rows without calling updateItem", async () => {
+  const updates = [];
+  const items = [makeQueuedItem(101), makeQueuedItem(102)];
+  const deps = makeDeps(items, updates);
+
+  const result = await forceDueQueuedItems(
+    { dry_run: true, now: FIXED_NOW },
+    deps
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.dry_run, true);
+  assert.equal(result.total_rows_loaded, 2);
+  assert.equal(result.eligible_rows, 2);
+  assert.equal(result.rescheduled_count, 0, "dry_run must not increment rescheduled_count");
+  assert.equal(updates.length, 0, "dry_run must not call updateItem");
+
+  // first_10_actions must be populated for preview purposes
+  assert.equal(result.first_10_actions.length, 2);
+  assert.equal(result.first_10_candidate_item_ids.length, 2);
+});
+
+// ─── 2. live mode rewrites schedule fields to now ────────────────────────────
+
+test("forceDueQueuedItems dry_run=false rewrites scheduled-for-utc and scheduled-for-local", async () => {
+  const updates = [];
+  const items = [makeQueuedItem(201)];
+  const deps = makeDeps(items, updates);
+
+  const result = await forceDueQueuedItems(
+    { dry_run: false, now: FIXED_NOW },
+    deps
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.dry_run, false);
+  assert.equal(result.rescheduled_count, 1);
+  assert.equal(updates.length, 1);
+
+  const { item_id, payload } = updates[0];
+  assert.equal(item_id, 201);
+
+  // UTC field must be set to now in Podio format
+  assert.deepEqual(payload["scheduled-for-utc"], { start: FIXED_NOW_PODIO_UTC });
+
+  // Local field must be set to now in Central local time
+  assert.deepEqual(payload["scheduled-for-local"], { start: FIXED_NOW_CENTRAL_LOCAL });
+});
+
+// ─── 3. non-Queued rows are excluded ─────────────────────────────────────────
+
+test("forceDueQueuedItems skips rows whose queue-status is not Queued", async () => {
+  const updates = [];
+  const items = [
+    makeQueuedItem(301, { "queue-status": "Sent" }),
+    makeQueuedItem(302, { "queue-status": "Failed" }),
+    makeQueuedItem(303, { "queue-status": "Queued" }),
+  ];
+  const deps = makeDeps(items, updates);
+
+  const result = await forceDueQueuedItems(
+    { dry_run: false, now: FIXED_NOW },
+    deps
+  );
+
+  assert.equal(result.total_rows_loaded, 3);
+  assert.equal(result.eligible_rows, 1, "only the Queued row is eligible");
+  assert.equal(result.rescheduled_count, 1);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].item_id, 303);
+});
+
+// ─── 4. master_owner_id scope filter works ───────────────────────────────────
+
+test("forceDueQueuedItems filters to master_owner_id when provided", async () => {
+  const updates = [];
+  const items = [
+    makeQueuedItem(401, { "master-owner": 111 }),
+    makeQueuedItem(402, { "master-owner": 222 }),
+    makeQueuedItem(403, { "master-owner": 111 }),
+  ];
+  const deps = makeDeps(items, updates);
+
+  const result = await forceDueQueuedItems(
+    { dry_run: false, master_owner_id: 111, now: FIXED_NOW },
+    deps
+  );
+
+  assert.equal(result.eligible_rows, 2);
+  assert.equal(result.rescheduled_count, 2);
+  assert.equal(result.master_owner_id, 111);
+  assert.deepEqual(
+    updates.map((u) => u.item_id).sort(),
+    [401, 403]
+  );
+});
+
+// ─── 5. response summary shape and first_10_actions content ──────────────────
+
+test("forceDueQueuedItems response summary contains required fields and first_10_actions shape", async () => {
+  const items = [makeQueuedItem(501), makeQueuedItem(502)];
+  const deps = makeDeps(items);
+
+  const result = await forceDueQueuedItems(
+    { dry_run: true, now: FIXED_NOW },
+    deps
+  );
+
+  // Top-level summary fields
+  for (const key of [
+    "ok", "dry_run", "run_started_at", "total_rows_loaded", "eligible_rows",
+    "rescheduled_count", "skipped_count", "master_owner_id",
+    "first_10_candidate_item_ids", "first_10_actions",
+  ]) {
+    assert.ok(key in result, `missing key: ${key}`);
+  }
+
+  // Per-action shape
+  const action = result.first_10_actions[0];
+  for (const key of [
+    "queue_item_id", "old_scheduled_utc", "new_scheduled_utc",
+    "old_scheduled_local", "new_scheduled_local", "timezone", "reason",
+  ]) {
+    assert.ok(key in action, `action missing key: ${key}`);
+  }
+
+  // new values must match now
+  assert.equal(action.new_scheduled_utc, FIXED_NOW_PODIO_UTC);
+  assert.equal(action.new_scheduled_local, FIXED_NOW_CENTRAL_LOCAL);
+  assert.equal(action.reason, "force_due_rescheduled");
+});
+
+// ─── 6. limit cap is respected ────────────────────────────────────────────────
+
+test("forceDueQueuedItems caps eligible_rows to the requested limit (hard cap 25)", async () => {
+  // Generate 30 items
+  const items = Array.from({ length: 30 }, (_, i) =>
+    makeQueuedItem(600 + i)
+  );
+  const deps = makeDeps(items);
+
+  const result_5 = await forceDueQueuedItems(
+    { dry_run: true, limit: 5, now: FIXED_NOW },
+    deps
+  );
+  assert.equal(result_5.eligible_rows, 5);
+  assert.equal(result_5.first_10_actions.length, 5);
+
+  const result_hard_cap = await forceDueQueuedItems(
+    { dry_run: true, limit: 100, now: FIXED_NOW },  // over hard cap
+    deps
+  );
+  assert.equal(
+    result_hard_cap.eligible_rows,
+    25,
+    "hard cap of 25 must be enforced even when limit=100"
+  );
+});
+
+// ─── 7. older_than_minutes filter: future rows pass, recent-due rows skip ─────
+
+test("forceDueQueuedItems older_than_minutes targets future and long-overdue rows only", async () => {
+  const FUTURE = "2026-04-06 10:00:00";       // 16 h from FIXED_NOW → future
+  const JUST_PAST = "2026-04-05 17:50:00";    // 10 min ago → inside threshold
+  const LONG_PAST = "2026-04-05 10:00:00";    // 8 h ago → overdue past threshold
+
+  const items = [
+    makeQueuedItem(701, { "scheduled-for-utc": FUTURE }),    // eligible
+    makeQueuedItem(702, { "scheduled-for-utc": JUST_PAST }), // skipped (within 30-min threshold)
+    makeQueuedItem(703, { "scheduled-for-utc": LONG_PAST }), // eligible
+  ];
+  const deps = makeDeps(items);
+
+  const result = await forceDueQueuedItems(
+    { dry_run: true, older_than_minutes: 30, now: FIXED_NOW },
+    deps
+  );
+
+  assert.equal(result.eligible_rows, 2);
+  assert.deepEqual(
+    result.first_10_candidate_item_ids.sort(),
+    [701, 703]
+  );
+});
+
+// ─── 8. timezone localization for non-Central rows ────────────────────────────
+
+test("forceDueQueuedItems localizes scheduled-for-local to the row's timezone", async () => {
+  const updates = [];
+  const items = [
+    makeQueuedItem(801, { timezone: "Eastern" }),
+    makeQueuedItem(802, { timezone: "Pacific" }),
+  ];
+  const deps = makeDeps(items, updates);
+
+  await forceDueQueuedItems({ dry_run: false, now: FIXED_NOW }, deps);
+
+  // FIXED_NOW = 2026-04-05T18:00:00Z
+  // Eastern (EDT = UTC-4): 14:00
+  // Pacific (PDT = UTC-7): 11:00
+  assert.equal(updates.length, 2);
+
+  const eastern = updates.find((u) => u.item_id === 801);
+  assert.ok(
+    eastern.payload["scheduled-for-local"].start.includes("14:00"),
+    `Eastern local expected 14:00, got ${eastern.payload["scheduled-for-local"].start}`
+  );
+
+  const pacific = updates.find((u) => u.item_id === 802);
+  assert.ok(
+    pacific.payload["scheduled-for-local"].start.includes("11:00"),
+    `Pacific local expected 11:00, got ${pacific.payload["scheduled-for-local"].start}`
+  );
+});
+
+// ─── 9. route handler: logs lifecycle events and defaults to dry_run=true ─────
+
+test("handleQueueForceDueRequest logs lifecycle events and defaults to dry_run=true", async () => {
+  const log_calls = [];
+  const logger = {
+    info: (event, meta) => log_calls.push({ level: "info", event, meta }),
+    warn: (event, meta) => log_calls.push({ level: "warn", event, meta }),
+    error: (event, meta) => log_calls.push({ level: "error", event, meta }),
+  };
+
+  const responses = [];
+  const json_response = (body, init) => {
+    const r = { body, status: init?.status ?? 200 };
+    responses.push(r);
+    return r;
+  };
+
+  const stub_result = {
+    ok: true,
+    dry_run: true,
+    total_rows_loaded: 3,
+    eligible_rows: 2,
+    rescheduled_count: 0,
+    skipped_count: 1,
+    master_owner_id: null,
+    first_10_candidate_item_ids: [101, 102],
+    first_10_actions: [],
+  };
+
+  await handleQueueForceDueRequest(
+    { url: "https://app.example.com/api/internal/queue/force-due" },
+    "GET",
+    {
+      requireCronAuth: () => ({
+        authorized: true,
+        auth: { authenticated: true, is_vercel_cron: false },
+        response: null,
+      }),
+      forceDueQueuedItems: async () => stub_result,
+      logger,
+      jsonResponse: json_response,
+    }
+  );
+
+  assert.equal(responses.length, 1);
+  assert.equal(responses[0].status, 200);
+  assert.equal(responses[0].body.ok, true);
+  assert.equal(responses[0].body.route, "internal/queue/force-due");
+  assert.deepEqual(responses[0].body.result, stub_result);
+
+  const events = log_calls.map((c) => c.event);
+  assert.ok(events.includes("queue_force_due.route_enter"), "must log route_enter");
+  assert.ok(events.includes("queue_force_due.requested"), "must log requested");
+  assert.ok(events.includes("queue_force_due.completed"), "must log completed");
+});
+
+// ─── 10. route handler: unauthorized returns early ───────────────────────────
+
+test("handleQueueForceDueRequest returns early without calling forceDueQueuedItems when auth fails", async () => {
+  const force_due_calls = [];
+  const sentinel = { sentinel: true };
+
+  const returned = await handleQueueForceDueRequest(
+    { url: "https://app.example.com/api/internal/queue/force-due" },
+    "GET",
+    {
+      requireCronAuth: () => ({
+        authorized: false,
+        auth: { authenticated: false, is_vercel_cron: false },
+        response: sentinel,
+      }),
+      forceDueQueuedItems: async () => {
+        force_due_calls.push(1);
+        return { ok: true };
+      },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      jsonResponse: () => {},
+    }
+  );
+
+  assert.equal(force_due_calls.length, 0, "forceDueQueuedItems must not be called when auth fails");
+  assert.equal(returned, sentinel, "must return the auth rejection response");
+});
+
+// ─── 11. skipped_count reflects excluded rows ────────────────────────────────
+
+test("forceDueQueuedItems skipped_count equals total_rows_loaded minus eligible_rows", async () => {
+  const items = [
+    makeQueuedItem(901),
+    makeQueuedItem(902, { "queue-status": "Sent" }),
+    makeQueuedItem(903, { "queue-status": "Failed" }),
+    makeQueuedItem(904),
+  ];
+  const deps = makeDeps(items);
+
+  const result = await forceDueQueuedItems(
+    { dry_run: true, now: FIXED_NOW },
+    deps
+  );
+
+  assert.equal(result.total_rows_loaded, 4);
+  assert.equal(result.eligible_rows, 2);
+  assert.equal(result.skipped_count, 2);
+  assert.equal(result.skipped_count, result.total_rows_loaded - result.eligible_rows);
+});


### PR DESCRIPTION
Adds a safe admin recovery tool that force-reschedules Queued rows
whose scheduled-for-utc is in the future (or long-overdue) so the
normal queue runner can pick them up immediately.

- src/app/api/internal/queue/force-due/route.js  – GET + POST, nodejs runtime
- src/lib/domain/queue/force-due-queued-items.js – domain logic with lazy podio
  loading, dry_run=true default, hard cap of 25 rows, timezone-aware local
  rescheduling, older_than_minutes filter
- src/lib/domain/queue/queue-force-due-request.js – thin request handler
  matching queue-run-request.js conventions (requireCronAuth, rollout controls,
  master_owner scoping, structured logs)
- tests/critical/queue-force-due.test.mjs – 11 focused tests (11/11 pass);
  no regressions in full critical suite (42/70 pass, same pre-existing failures)

https://claude.ai/code/session_01Qx1iq2QWDyYCEpkwNvEYHU