### PR TITLE
Stabilize inbound normalization, queue payload integrity, and seller-flow lane gating

### DIFF
--- a/src/app/api/internal/verification/replay/route.js
+++ b/src/app/api/internal/verification/replay/route.js
@@ -7,6 +7,8 @@ import { handleTextgridDeliveryWebhook } from "@/lib/flows/handle-textgrid-deliv
 import { handleDocusignWebhook } from "@/lib/domain/contracts/handle-docusign-webhook.js";
 import { handleTitleResponseWebhook } from "@/lib/domain/title/handle-title-response-webhook.js";
 import { handleClosingResponseWebhook } from "@/lib/domain/closings/handle-closing-response-webhook.js";
+import { processSendQueueItem } from "@/lib/domain/queue/process-send-queue.js";
+import { queueOutboundMessage } from "@/lib/flows/queue-outbound-message.js";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -15,12 +17,26 @@ const logger = child({
   module: "api.internal.verification.replay",
 });
 
+async function replayQueueSend(payload = {}) {
+  const queue_item_id = Number(payload?.queue_item_id || payload?.id || 0);
+  if (!Number.isFinite(queue_item_id) || queue_item_id <= 0) {
+    return {
+      ok: false,
+      reason: "missing_queue_item_id",
+    };
+  }
+
+  return processSendQueueItem(queue_item_id);
+}
+
 const FLOW_HANDLERS = {
   textgrid_inbound: handleTextgridInboundWebhook,
   textgrid_delivery: handleTextgridDeliveryWebhook,
   docusign: handleDocusignWebhook,
   title: handleTitleResponseWebhook,
   closings: handleClosingResponseWebhook,
+  queue_send: replayQueueSend,
+  queue_build: queueOutboundMessage,
 };
 
 function clean(value) {

--- a/src/app/api/webhooks/textgrid/inbound/route.js
+++ b/src/app/api/webhooks/textgrid/inbound/route.js
@@ -4,6 +4,7 @@ import { maybeHandleBuyerTextgridInbound } from "@/lib/domain/buyers/handle-buye
 import { child } from "@/lib/logging/logger.js";
 import { handleTextgridInbound } from "@/lib/flows/handle-textgrid-inbound.js";
 import { verifyTextgridWebhookSignature } from "@/lib/providers/textgrid.js";
+import { normalizeTextgridInboundPayload } from "@/lib/webhooks/textgrid-inbound-normalize.js";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -35,63 +36,7 @@ async function parseRequestBody(request) {
   return { raw_text: text };
 }
 
-function normalizeInboundPayload(body = {}, headers) {
-  return {
-    provider: "textgrid",
-    raw: body,
-
-    message_id: clean(
-      body?.message_id ||
-      body?.messageId ||
-      body?.id ||
-      body?.sms_id
-    ),
-
-    from: clean(
-      body?.from ||
-      body?.from_number ||
-      body?.fromNumber ||
-      body?.sender ||
-      body?.phone
-    ),
-
-    to: clean(
-      body?.to ||
-      body?.to_number ||
-      body?.toNumber ||
-      body?.recipient
-    ),
-
-    message: clean(
-      body?.message ||
-      body?.body ||
-      body?.text ||
-      body?.content
-    ),
-
-    direction: clean(body?.direction || "inbound"),
-    received_at: clean(
-      body?.received_at ||
-      body?.timestamp ||
-      body?.created_at
-    ),
-    conversation_id: clean(body?.conversation_id || body?.conversationId),
-    account_id: clean(body?.account_id || body?.accountId),
-    status: clean(body?.status || "received"),
-
-    header_signature: clean(
-      headers.get("x-textgrid-signature") ||
-      headers.get("x-signature") ||
-      ""
-    ),
-    header_event: clean(
-      headers.get("x-textgrid-event") ||
-      headers.get("x-event-type") ||
-      "inbound"
-    ),
-    http_received_at: new Date().toISOString(),
-  };
-}
+export const __normalizeInboundPayloadForTest = normalizeTextgridInboundPayload;
 
 export async function GET() {
   return NextResponse.json({
@@ -105,7 +50,7 @@ export async function POST(request) {
   try {
     const raw_body = await request.clone().text().catch(() => "");
     const body = await parseRequestBody(request);
-    const payload = normalizeInboundPayload(body, request.headers);
+    const payload = normalizeTextgridInboundPayload(body, request.headers);
     const verification = verifyTextgridWebhookSignature({
       raw_body,
       signature: payload.header_signature,

--- a/src/lib/domain/events/log-inbound-message-event.js
+++ b/src/lib/domain/events/log-inbound-message-event.js
@@ -37,6 +37,7 @@ export async function logInboundMessageEvent({
   message_body = "",
   provider_message_id = null,
   raw_carrier_status = "received",
+  received_at = null,
   processed_by = "Inbound Webhook",
   source_app = "TextGrid",
   trigger_name = "textgrid-inbound",
@@ -47,7 +48,7 @@ export async function logInboundMessageEvent({
   const fields = {
     [EVENT_FIELDS.message_id]: provider_message_id || null,
     [EVENT_FIELDS.direction]: "Inbound",
-    [EVENT_FIELDS.timestamp]: { start: nowIso() },
+    [EVENT_FIELDS.timestamp]: { start: received_at || nowIso() },
     [EVENT_FIELDS.message]: normalized_message,
     [EVENT_FIELDS.character_count]: normalized_message.length,
     [EVENT_FIELDS.delivery_status]: "Received",

--- a/src/lib/domain/offers/select-offer-strategy.js
+++ b/src/lib/domain/offers/select-offer-strategy.js
@@ -76,9 +76,9 @@ function deriveSignals({
     normalized_property_type.includes("apartment") ||
     normalized_property_type.includes("5+") ||
     normalized_property_type.includes("commercial multifamily") ||
-    normalized_unit_count >= 2 ||
-    hasTag(tags, ["multifamily", "multi-family", "duplex", "triplex", "fourplex", "apartments"]) ||
-    includesAny(normalized_notes, ["duplex", "triplex", "fourplex", "units", "doors", "apartments"]);
+    normalized_unit_count >= 5 ||
+    hasTag(tags, ["multifamily", "multi-family", "apartments", "5+ units"]) ||
+    includesAny(normalized_notes, ["5 unit", "5+ unit", "apartment building", "apartments"]);
 
   const is_distressed =
     hasTag(tags, [

--- a/src/lib/domain/queue/build-send-queue-item.js
+++ b/src/lib/domain/queue/build-send-queue-item.js
@@ -466,6 +466,7 @@ export async function buildSendQueueItem({
   property_type = null,
   secondary_category = null,
   use_case_template = null,
+  personalization_tags_used: explicit_personalization_tags_used = null,
   create_item = createItem,
   update_item = updateItem,
 }) {
@@ -565,13 +566,15 @@ export async function buildSendQueueItem({
     getTextValue(market_item, "title", "") ||
     "";
 
-  const personalization_tags_used = derivePersonalizationTagsUsed({
-    message_text,
-    owner_name,
-    property_address,
-    agent_name,
-    market_name,
-  });
+  const personalization_tags_used = Array.isArray(explicit_personalization_tags_used)
+    ? unique(explicit_personalization_tags_used.map((tag) => clean(tag)).filter(Boolean))
+    : derivePersonalizationTagsUsed({
+        message_text,
+        owner_name,
+        property_address,
+        agent_name,
+        market_name,
+      });
 
   const next_touch_number =
     touch_number ??

--- a/src/lib/domain/seller-flow/route-seller-conversation.js
+++ b/src/lib/domain/seller-flow/route-seller-conversation.js
@@ -311,10 +311,6 @@ function normalizePropertyType(value = "") {
       "apartments",
       "5+ unit",
       "commercial multifamily",
-      "duplex",
-      "triplex",
-      "quadplex",
-      "fourplex",
     ])
   ) {
     return "Multifamily";
@@ -341,7 +337,7 @@ function isMultifamilyLike({ context = null, signals = {} } = {}) {
 
   return (
     property_type === "Multifamily" ||
-    (Number.isFinite(Number(unit_count)) && Number(unit_count) >= 2)
+    (Number.isFinite(Number(unit_count)) && Number(unit_count) >= 5)
   );
 }
 

--- a/src/lib/domain/underwriting/maybe-queue-underwriting-follow-up.js
+++ b/src/lib/domain/underwriting/maybe-queue-underwriting-follow-up.js
@@ -98,12 +98,10 @@ function isMultifamily({ property_type = "", unit_count = null, route = null } =
       "multi family",
       "apartment",
       "apartments",
-      "duplex",
-      "triplex",
-      "quadplex",
-      "fourplex",
+      "5+ unit",
+      "commercial multifamily",
     ]) ||
-    (unit_count !== null && unit_count >= 2) ||
+    (unit_count !== null && unit_count >= 5) ||
     route?.is_multifamily_like === true
   );
 }

--- a/src/lib/flows/handle-textgrid-inbound.js
+++ b/src/lib/flows/handle-textgrid-inbound.js
@@ -71,6 +71,9 @@ function extractWebhookPayload(payload = {}) {
     payload.id ||
     payload.message_id ||
     payload.messageId ||
+    payload.SmsMessageSid ||
+    payload.SmsSid ||
+    payload.MessageSid ||
     null;
 
   const from =
@@ -78,12 +81,14 @@ function extractWebhookPayload(payload = {}) {
     payload.sender ||
     payload.msisdn ||
     payload.contact?.phone ||
+    payload.From ||
     null;
 
   const to =
     payload.to ||
     payload.recipient ||
     payload.phone_number ||
+    payload.To ||
     null;
 
   const body =
@@ -91,13 +96,22 @@ function extractWebhookPayload(payload = {}) {
     payload.message ||
     payload.text ||
     payload.content ||
+    payload.Body ||
     "";
 
   const status =
     payload.status ||
+    payload.SmsStatus ||
     payload.event_type ||
     payload.event ||
     "received";
+
+  const received_at =
+    payload.received_at ||
+    payload.http_received_at ||
+    payload.timestamp ||
+    payload.created_at ||
+    null;
 
   return {
     raw: payload,
@@ -106,6 +120,7 @@ function extractWebhookPayload(payload = {}) {
     to,
     body: String(body || "").trim(),
     status,
+    received_at,
   };
 }
 
@@ -266,6 +281,7 @@ export async function handleTextgridInboundWebhook(payload = {}) {
       message_body,
       provider_message_id: extracted.message_id,
       raw_carrier_status: extracted.status || "received",
+      received_at: extracted.received_at || payload?.http_received_at || new Date().toISOString(),
       processed_by: "Inbound Webhook",
       source_app: "TextGrid",
       trigger_name: "textgrid-inbound",

--- a/src/lib/flows/queue-outbound-message.js
+++ b/src/lib/flows/queue-outbound-message.js
@@ -5,6 +5,7 @@ import { resolveRoute } from "@/lib/domain/routing/resolve-route.js";
 import { loadTemplate } from "@/lib/domain/templates/load-template.js";
 import { renderTemplate } from "@/lib/domain/templates/render-template.js";
 import { buildSendQueueItem } from "@/lib/domain/queue/build-send-queue-item.js";
+import { normalizeSellerFlowUseCase } from "@/lib/domain/seller-flow/canonical-seller-flow.js";
 import {
   resolveQueueSchedule,
   resolveSchedulingContactWindow,
@@ -451,6 +452,7 @@ export async function queueOutboundMessage({
     null;
 
   let final_message_text = clean(rendered_message_text);
+  let rendered_placeholders = [];
 
   if (!final_message_text) {
     const template_text = selected_template?.text || "";
@@ -498,6 +500,9 @@ export async function queueOutboundMessage({
     }
 
     final_message_text = clean(render_result?.rendered_text || "");
+    rendered_placeholders = Array.isArray(render_result?.used_placeholders)
+      ? render_result.used_placeholders
+      : [];
   }
 
   if (!final_message_text) {
@@ -604,7 +609,9 @@ export async function queueOutboundMessage({
     // matching option in the Send Queue schema (e.g. stale supplement).
     property_type: selected_template?.category_primary ?? resolved_category ?? null,
     secondary_category: resolved_secondary_category,
-    use_case_template: selected_template?.use_case ?? null,
+    use_case_template:
+      normalizeSellerFlowUseCase(selected_template?.use_case || resolved_use_case) || null,
+    personalization_tags_used: rendered_placeholders,
   });
 
   info("outbound.queue_message_completed", {

--- a/src/lib/webhooks/textgrid-inbound-normalize.js
+++ b/src/lib/webhooks/textgrid-inbound-normalize.js
@@ -1,0 +1,77 @@
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+export function normalizeTextgridInboundPayload(body = {}, headers = new Headers()) {
+  const http_received_at = new Date().toISOString();
+
+  return {
+    provider: "textgrid",
+    raw: body,
+
+    message_id: clean(
+      body?.message_id ||
+      body?.messageId ||
+      body?.id ||
+      body?.sms_id ||
+      body?.SmsMessageSid ||
+      body?.SmsSid ||
+      body?.MessageSid
+    ),
+
+    from: clean(
+      body?.from ||
+      body?.from_number ||
+      body?.fromNumber ||
+      body?.sender ||
+      body?.phone ||
+      body?.From
+    ),
+
+    to: clean(
+      body?.to ||
+      body?.to_number ||
+      body?.toNumber ||
+      body?.recipient ||
+      body?.To
+    ),
+
+    message: clean(
+      body?.message ||
+      body?.body ||
+      body?.text ||
+      body?.content ||
+      body?.Body
+    ),
+
+    direction: clean(body?.direction || "inbound"),
+    received_at: clean(
+      body?.received_at ||
+      body?.timestamp ||
+      body?.created_at ||
+      body?.http_received_at ||
+      http_received_at
+    ),
+    conversation_id: clean(body?.conversation_id || body?.conversationId),
+    account_id: clean(body?.account_id || body?.accountId),
+    status: clean(
+      body?.status ||
+      body?.SmsStatus ||
+      "received"
+    ),
+
+    header_signature: clean(
+      headers.get("x-textgrid-signature") ||
+      headers.get("x-signature") ||
+      ""
+    ),
+    header_event: clean(
+      headers.get("x-textgrid-event") ||
+      headers.get("x-event-type") ||
+      "inbound"
+    ),
+    http_received_at,
+  };
+}
+
+export default normalizeTextgridInboundPayload;

--- a/tests/critical/queue-payload-builder.test.mjs
+++ b/tests/critical/queue-payload-builder.test.mjs
@@ -171,6 +171,18 @@ test("Part 1 — single-line message-text is written unchanged (no regression)",
   assert.equal(captured_fields?.["character-count"], single.length);
 });
 
+test("Part 1 — explicit personalization tags are persisted exactly when provided", async () => {
+  const { captured_fields } = await buildAndCapture({
+    rendered_message_text: "Hi there",
+    personalization_tags_used: ["{{seller_first_name}}", "{{property_city}}"],
+  });
+
+  assert.deepEqual(captured_fields?.["personalization-tags-used"], [
+    "{{seller_first_name}}",
+    "{{property_city}}",
+  ]);
+});
+
 // ── Part 2: property-address ──────────────────────────────────────────────────
 
 test("Part 2 — property-address written when real property_id and address available", async () => {

--- a/tests/critical/seller-flow-routing.test.mjs
+++ b/tests/critical/seller-flow-routing.test.mjs
@@ -150,6 +150,20 @@ test("seller flow keeps multifamily leads in underwriting instead of jumping str
   assert.match(plan.reasoning_summary, /underwriting/i);
 });
 
+test("seller flow keeps 1-4 unit properties in the property lane", () => {
+  const plan = route({
+    previous_use_case: SELLER_FLOW_STAGES.ASKING_PRICE,
+    previous_stage: SELLER_FLOW_STAGES.ASKING_PRICE,
+    property_type: "Single Family",
+    unit_count: 4,
+    max_cash_offer: 155000,
+    message: "I'd need 170000.",
+  });
+
+  assert.equal(plan.selected_use_case, SELLER_FLOW_STAGES.PRICE_HIGH_CONDITION_PROBE);
+  assert.equal(plan.next_expected_stage, SELLER_FLOW_STAGES.PRICE_HIGH_CONDITION_PROBE);
+});
+
 test("seller flow routes negotiation branches to the canonical stage-6 handlers", () => {
   const justify_price = route({
     previous_use_case: SELLER_FLOW_STAGES.OFFER_REVEAL_CASH,

--- a/tests/critical/textgrid-inbound-normalization.test.mjs
+++ b/tests/critical/textgrid-inbound-normalization.test.mjs
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeTextgridInboundPayload } from "@/lib/webhooks/textgrid-inbound-normalize.js";
+import { handleTextgridInboundWebhook, __setTextgridInboundTestDeps, __resetTextgridInboundTestDeps } from "@/lib/flows/handle-textgrid-inbound.js";
+import { createInMemoryIdempotencyLedger, createPodioItem } from "../helpers/test-helpers.js";
+
+test("inbound route normalizer maps Twilio/TextGrid webhook fields", () => {
+  const payload = normalizeTextgridInboundPayload(
+    {
+      SmsMessageSid: "SM123",
+      SmsSid: "SM999",
+      From: "+15551230001",
+      To: "+15559870002",
+      Body: "Hello there",
+      SmsStatus: "received",
+    },
+    new Headers()
+  );
+
+  assert.equal(payload.message_id, "SM123");
+  assert.equal(payload.from, "+15551230001");
+  assert.equal(payload.to, "+15559870002");
+  assert.equal(payload.message, "Hello there");
+  assert.equal(payload.status, "received");
+  assert.ok(payload.received_at);
+});
+
+test("inbound handler accepts raw Twilio/TextGrid payload and logs inbound event", async (t) => {
+  const ledger = createInMemoryIdempotencyLedger();
+  let logged_payload = null;
+
+  __setTextgridInboundTestDeps({
+    beginIdempotentProcessing: ledger.begin,
+    completeIdempotentProcessing: ledger.complete,
+    failIdempotentProcessing: ledger.fail,
+    hashIdempotencyPayload: ledger.hash,
+    normalizeInboundTextgridPhone: (value) => value,
+    info: () => {},
+    warn: () => {},
+    loadContext: async () => ({
+      found: true,
+      ids: {
+        brain_item_id: 11,
+        master_owner_id: 21,
+        prospect_id: 31,
+        property_id: 41,
+        phone_item_id: 51,
+      },
+      items: {
+        brain_item: createPodioItem(11),
+        phone_item: createPodioItem(51),
+      },
+    }),
+    classify: async () => ({ language: "English", source: "test" }),
+    resolveRoute: () => ({ stage: "Ownership", use_case: "ownership_check", seller_profile: null }),
+    logInboundMessageEvent: async (payload) => {
+      logged_payload = payload;
+      return { item_id: 991 };
+    },
+    updateBrainAfterInbound: async () => {},
+    updateMasterOwnerAfterInbound: async () => ({ ok: true }),
+    updateBrainStage: async () => ({ ok: true }),
+    updateBrainLanguage: async () => ({ ok: true }),
+    updateBrainSellerProfile: async () => ({ ok: true }),
+    findLatestOpenOffer: async () => null,
+    maybeProgressOfferStatus: async () => ({ ok: true, updated: false }),
+    maybeCreateOfferFromContext: async () => ({ ok: true, created: false }),
+    maybeUpsertUnderwritingFromInbound: async () => ({ ok: true, extracted: false }),
+    maybeQueueSellerStageReply: async () => ({ ok: true, handled: false, queued: false }),
+    maybeQueueUnderwritingFollowUp: async () => ({ ok: true, queued: false }),
+    maybeCreateContractFromAcceptedOffer: async () => ({ ok: true, created: false }),
+    syncPipelineState: async () => ({ pipeline_item_id: 61, current_stage: "Ownership" }),
+  });
+
+  t.after(() => {
+    __resetTextgridInboundTestDeps();
+  });
+
+  const result = await handleTextgridInboundWebhook({
+    SmsMessageSid: "SM123",
+    From: "+15551230001",
+    To: "+15559870002",
+    Body: "Yes, I own it",
+    SmsStatus: "received",
+    http_received_at: "2026-04-08T00:00:00.000Z",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.message_id, "SM123");
+  assert.equal(result.inbound_from, "+15551230001");
+  assert.equal(result.body, "Yes, I own it");
+  assert.equal(logged_payload.provider_message_id, "SM123");
+  assert.equal(logged_payload.received_at, "2026-04-08T00:00:00.000Z");
+});


### PR DESCRIPTION
### Motivation
- Normalize incoming TextGrid/Twilio-style webhook payloads before validation because Twilio-style capitalized fields were not mapped and caused valid inbound requests to be rejected. 
- Preserve webhook receipt timestamp and improve message-event persistence to avoid losing inbound timing data. 
- Ensure queue rows carry correct template/use-case metadata and explicit personalization tag lists from the renderer. 
- Align multifamily vs property lane routing with the updated business rule (1–4 units = property, 5+ = building). 

### Description
- Added a reusable inbound normalizer `src/lib/webhooks/textgrid-inbound-normalize.js` that maps `SmsMessageSid|SmsSid|MessageSid`, `From`, `To`, `Body`, `SmsStatus`, and produces a consistent `received_at` fallback. 
- Updated the webhook route `src/app/api/webhooks/textgrid/inbound/route.js` to use the new normalizer and keep signature verification unchanged. 
- Extended inbound flow extraction in `src/lib/flows/handle-textgrid-inbound.js` to accept Twilio-style raw keys and to surface `received_at` through the flow and idempotency metadata. 
- Persisted inbound event timestamp into Podio message events in `src/lib/domain/events/log-inbound-message-event.js`. 
- Allowed explicit personalization tag lists from the renderer to be written into the Send Queue by adding an optional `personalization_tags_used` override in `src/lib/domain/queue/build-send-queue-item.js`. 
- Propagated renderer-used placeholders into outbound queue builder (`src/lib/flows/queue-outbound-message.js`) and canonicalized use-case slug via `normalizeSellerFlowUseCase`. 
- Adjusted multifamily/building gating to require 5+ units for building lane in `src/lib/domain/seller-flow/route-seller-conversation.js`, `src/lib/domain/underwriting/maybe-queue-underwriting-follow-up.js`, and `src/lib/domain/offers/select-offer-strategy.js`. 
- Extended verification/replay handler (`src/app/api/internal/verification/replay/route.js`) with `queue_send` (replay a queue send by `queue_item_id`) and `queue_build` (replay queue build) flows for observability and reruns. 
- Tests added/updated: new inbound normalizer tests and adjustments to queue/payload and seller-flow tests. 

### Testing
- Ran lint: `npm run lint` (syntax checks passed). 
- Added and ran focused tests via the critical runner for the patched areas: `NODE_ENV=test ... node --import ./tests/register-aliases.mjs --test --test-concurrency=1 tests/critical/textgrid-inbound-normalization.test.mjs tests/critical/queue-payload-builder.test.mjs tests/critical/seller-flow-routing.test.mjs tests/critical/replay-handlers.test.mjs` and observed all tests in that selection passed. 
- Note: a full `npm run test:critical` suite still shows unrelated baseline failures in existing context/property-summary tests that predate these changes; those were not introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d629b910388331b36f9f18409d4673)