### PR TITLE
Suppress duplicate Send Queue inserts and align queued message with selected template

### DIFF
--- a/src/lib/flows/queue-outbound-message.js
+++ b/src/lib/flows/queue-outbound-message.js
@@ -11,7 +11,13 @@ import {
   resolveSchedulingContactWindow,
 } from "@/lib/domain/queue/queue-schedule.js";
 import { chooseTextgridNumber } from "@/lib/domain/routing/choose-textgrid-number.js";
-import { normalizeUsPhone10 } from "@/lib/providers/podio.js";
+import {
+  getCategoryValue,
+  getFirstAppReferenceId,
+  getNumberValue,
+  normalizeUsPhone10,
+} from "@/lib/providers/podio.js";
+import { findQueueItems } from "@/lib/podio/queries/find-queue-items.js";
 import { info, warn } from "@/lib/logging/logger.js";
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -174,6 +180,25 @@ function deriveNextTouchNumber({
     0;
 
   return Math.max(1, Number(historical_touch_count || 0) + 1);
+}
+
+const PENDING_QUEUE_STATUSES = new Set(["queued", "sending"]);
+
+export function findPendingQueueDuplicateItem(queue_items = [], phone_item_id, touch_number) {
+  if (!phone_item_id) return null;
+
+  return (
+    queue_items.find((item) => {
+      const status = clean(getCategoryValue(item, "queue-status", "")).toLowerCase();
+      if (!PENDING_QUEUE_STATUSES.has(status)) return false;
+
+      const candidate_phone_id = getFirstAppReferenceId(item, "phone-number", null);
+      if (String(candidate_phone_id || "") !== String(phone_item_id || "")) return false;
+
+      const candidate_touch = Number(getNumberValue(item, "touch-number", 0) || 0);
+      return candidate_touch === Number(touch_number || 0);
+    }) || null
+  );
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -402,7 +427,7 @@ export async function queueOutboundMessage({
 
   let selected_template = template_item || null;
 
-  if (!selected_template && !clean(rendered_message_text)) {
+  if (!selected_template && !template_id) {
     selected_template = await loadTemplate({
       category: resolved_category,
       secondary_category: resolved_template_lookup_secondary_category,
@@ -451,10 +476,10 @@ export async function queueOutboundMessage({
     selected_template?.item_id ||
     null;
 
-  let final_message_text = clean(rendered_message_text);
+  let final_message_text = "";
   let rendered_placeholders = [];
 
-  if (!final_message_text) {
+  if (selected_template) {
     const template_text = selected_template?.text || "";
 
     const render_result = renderTemplate({
@@ -503,6 +528,8 @@ export async function queueOutboundMessage({
     rendered_placeholders = Array.isArray(render_result?.used_placeholders)
       ? render_result.used_placeholders
       : [];
+  } else {
+    final_message_text = clean(rendered_message_text);
   }
 
   if (!final_message_text) {
@@ -575,7 +602,43 @@ export async function queueOutboundMessage({
           timezone_label: resolved_timezone,
           contact_window: resolved_contact_window,
           distribution_key: resolved_rotation_key,
-        });
+      });
+
+  const queue_history = await findQueueItems({
+    filters: {
+      "phone-number": Number(context?.ids?.phone_item_id || 0) || undefined,
+    },
+    limit: 25,
+  });
+
+  const duplicate_queue_item = findPendingQueueDuplicateItem(
+    queue_history,
+    context?.ids?.phone_item_id || null,
+    resolved_touch_number
+  );
+
+  if (duplicate_queue_item) {
+    warn("outbound.queue_message_duplicate_suppressed", {
+      inbound_from: resolved_inbound_from,
+      phone_item_id: context?.ids?.phone_item_id || null,
+      duplicate_queue_item_id: duplicate_queue_item?.item_id || null,
+      duplicate_touch_number: resolved_touch_number,
+      duplicate_queue_status: getCategoryValue(duplicate_queue_item, "queue-status", null),
+    });
+
+    return {
+      ok: false,
+      stage: "duplicate_guard",
+      reason: "duplicate_pending_queue_item",
+      inbound_from: normalized_inbound_from,
+      duplicate_queue_item_id: duplicate_queue_item?.item_id || null,
+      duplicate_touch_number: resolved_touch_number,
+      duplicate_queue_status: getCategoryValue(duplicate_queue_item, "queue-status", null),
+      context,
+      classification,
+      route,
+    };
+  }
 
   const queue_result = await buildSendQueueItem({
     context,

--- a/tests/critical/queue-outbound-duplicate-guard.test.mjs
+++ b/tests/critical/queue-outbound-duplicate-guard.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { findPendingQueueDuplicateItem } from "@/lib/flows/queue-outbound-message.js";
+import {
+  appRefField,
+  categoryField,
+  numberField,
+  createPodioItem,
+} from "../helpers/test-helpers.js";
+
+function createQueueItem(item_id, { phone_item_id, queue_status, touch_number }) {
+  return createPodioItem(item_id, {
+    "phone-number": appRefField(phone_item_id),
+    "queue-status": categoryField(queue_status),
+    "touch-number": numberField(touch_number),
+  });
+}
+
+test("findPendingQueueDuplicateItem finds pending same-phone same-touch duplicate", () => {
+  const duplicate = findPendingQueueDuplicateItem(
+    [
+      createQueueItem(1001, { phone_item_id: 401, queue_status: "Queued", touch_number: 2 }),
+      createQueueItem(1002, { phone_item_id: 401, queue_status: "Sent", touch_number: 2 }),
+    ],
+    401,
+    2
+  );
+
+  assert.ok(duplicate);
+  assert.equal(duplicate.item_id, 1001);
+});
+
+test("findPendingQueueDuplicateItem ignores rows with different touch-number", () => {
+  const duplicate = findPendingQueueDuplicateItem(
+    [
+      createQueueItem(1001, { phone_item_id: 401, queue_status: "Queued", touch_number: 1 }),
+      createQueueItem(1002, { phone_item_id: 401, queue_status: "Sending", touch_number: 3 }),
+    ],
+    401,
+    2
+  );
+
+  assert.equal(duplicate, null);
+});
+


### PR DESCRIPTION
### Motivation

- Prevent duplicate Send Queue rows being created for the same phone + touch number when there is already a pending row, which caused duplicate sends and race conditions.
- Ensure the queued message text is consistent with the template relation so the `template` linked in Send Queue matches the `message-text` stored.

### Description

- Added `findPendingQueueDuplicateItem` and a pending-duplicate guard in `queueOutboundMessage` that queries existing Send Queue rows via `findQueueItems` and suppresses enqueue when a `Queued`/`Sending` duplicate exists.
- Imported Podio helpers (`getCategoryValue`, `getFirstAppReferenceId`, `getNumberValue`, `normalizeUsPhone10`) and `findQueueItems` to resolve duplicate detection and inspect queue rows.
- Changed template/message assembly to prefer rendering from the resolved `selected_template` when present and only fallback to `rendered_message_text` when no template is used, preserving linkage and message alignment.
- Added unit tests `tests/critical/queue-outbound-duplicate-guard.test.mjs` that exercise the duplicate detection helper semantics (same-phone+same-touch blocks; different touch does not).

### Testing

- Ran the targeted critical tests with `node --import ./tests/register-aliases.mjs --test tests/critical/queue-outbound-duplicate-guard.test.mjs tests/critical/queue-relation-persistence.test.mjs` under the test environment; all tests passed.
- Test run summary: 7 tests executed and all passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6310c43288331b89c9a563af3b5ff)