### PR TITLE
merge supabase sms execution path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "real-estate-automation",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.103.3",
         "axios": "^1.6.0",
         "next": "^14.2.0",
         "openai": "^4.0.0",
@@ -168,6 +169,92 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.3.tgz",
+      "integrity": "sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.3.tgz",
+      "integrity": "sha512-A2ZHi95GIRRlN9LGOSa/zGEIPg9taR1giDI9Gkfkgrcz0YmKV8ShiAplIrKsHQFdkzKxtsO3maJF0efL+i31mg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.3.tgz",
+      "integrity": "sha512-S0k/9FJVXDeejNfQLCJwRlm4IH8Wet/HEEdBTBpX6/G2o1eU/6CjQop/hJPZIwlQkI6D/zbHH8KymuCsBgy6jA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.3.tgz",
+      "integrity": "sha512-fUvKtSXMUk1BkApVwAurWtHF4Vzbb0UB9aC/fQXrRBek7Ta3Kaora+wHf/fGwFNQs7uRz+mvjIVpzLfpR32VXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.3.tgz",
+      "integrity": "sha512-5bAIEubrw5keHcdKR2RTois0O1M2Ilx4UYuzOzc07G6mLGCPS/8t1nbC6Vq451pnxR3sK+rmtFHWb9CY/OPjAw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.3.tgz",
+      "integrity": "sha512-DuPiAz5pIJsTAQCt7B6bDZrnLzlq9+/5bta/GWTsgpLn6AkuZQcmYsQHYplv4skQ8U2raKY5HASQOu4KtYq9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.103.3",
+        "@supabase/functions-js": "2.103.3",
+        "@supabase/postgrest-js": "2.103.3",
+        "@supabase/realtime-js": "2.103.3",
+        "@supabase/storage-js": "2.103.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -201,6 +288,15 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abort-controller": {
@@ -548,6 +644,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -900,6 +1005,27 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.103.3",
     "axios": "^1.6.0",
     "next": "^14.2.0",
     "openai": "^4.0.0",

--- a/src/app/api/dev/env-check/route.js
+++ b/src/app/api/dev/env-check/route.js
@@ -2,6 +2,10 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  const supabase_env_keys = Object.keys(process.env)
+    .filter((key) => key.includes("SUPABASE"))
+    .sort();
+
   return Response.json({
     ok: true,
     env: {
@@ -12,8 +16,12 @@ export async function GET() {
       TEXTGRID_ACCOUNT_SID: !!process.env.TEXTGRID_ACCOUNT_SID,
       TEXTGRID_AUTH_TOKEN: !!process.env.TEXTGRID_AUTH_TOKEN,
       CRON_SECRET: !!process.env.CRON_SECRET,
-      VERCEL_ENV: process.env.VERCEL_ENV || null,
-      NODE_ENV: process.env.NODE_ENV || null,
+      VERCEL_GIT_COMMIT_SHA: !!process.env.VERCEL_GIT_COMMIT_SHA,
+      VERCEL_URL: !!process.env.VERCEL_URL,
+      VERCEL_TARGET_ENV: !!process.env.VERCEL_TARGET_ENV,
+      VERCEL_ENV: !!process.env.VERCEL_ENV,
+      NODE_ENV: !!process.env.NODE_ENV,
+      SUPABASE_ENV_KEYS: supabase_env_keys,
     },
   });
 }

--- a/src/app/api/dev/env-check/route.js
+++ b/src/app/api/dev/env-check/route.js
@@ -1,0 +1,19 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return Response.json({
+    ok: true,
+    env: {
+      SUPABASE_URL: !!process.env.SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY: !!process.env.SUPABASE_SERVICE_ROLE_KEY,
+      NEXT_PUBLIC_SUPABASE_URL: !!process.env.NEXT_PUBLIC_SUPABASE_URL,
+      SUPABASE_SERVICE_KEY: !!process.env.SUPABASE_SERVICE_KEY,
+      TEXTGRID_ACCOUNT_SID: !!process.env.TEXTGRID_ACCOUNT_SID,
+      TEXTGRID_AUTH_TOKEN: !!process.env.TEXTGRID_AUTH_TOKEN,
+      CRON_SECRET: !!process.env.CRON_SECRET,
+      VERCEL_ENV: process.env.VERCEL_ENV || null,
+      NODE_ENV: process.env.NODE_ENV || null,
+    },
+  });
+}

--- a/src/app/api/dev/force-send/route.js
+++ b/src/app/api/dev/force-send/route.js
@@ -1,0 +1,28 @@
+import { sendTextgridSMS } from "@/lib/providers/textgrid.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const result = await sendTextgridSMS({
+      from: "+16128060495",
+      to: "+16127433952",
+      body: "🔥 FORCE SEND TEST",
+    });
+
+    console.log("FORCE SEND RESULT:", result);
+
+    return Response.json({
+      success: true,
+      result,
+    });
+  } catch (err) {
+    console.error("FORCE SEND ERROR:", err);
+
+    return Response.json({
+      success: false,
+      error: err?.message || "Unknown error",
+    });
+  }
+}

--- a/src/app/api/dev/send-test/route.js
+++ b/src/app/api/dev/send-test/route.js
@@ -1,18 +1,71 @@
 import crypto from "node:crypto";
 
-import { runSendQueue } from "@/lib/domain/queue/run-send-queue.js";
 import { insertSupabaseSendQueueRow } from "@/lib/supabase/sms-engine.js";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function getRequestUrl(request_url = "http://localhost/api/dev/send-test") {
+  return new URL(request_url);
+}
+
+function buildQueueRunUrl(request_url) {
+  const url = getRequestUrl(request_url);
+  return new URL("/api/internal/queue/run", url.origin).toString();
+}
+
+function buildQueueRunHeaders() {
+  const cron_secret = clean(process.env.CRON_SECRET);
+  const headers = {};
+
+  if (cron_secret) {
+    headers.Authorization = `Bearer ${cron_secret}`;
+    headers["x-vercel-cron-secret"] = cron_secret;
+  }
+
+  return headers;
+}
+
+function parsePhoneOverride(value, fallback) {
+  const normalized = clean(value).replace(/\s+/g, "");
+  return normalized || fallback;
+}
+
+async function parseQueueRunResponse(response) {
+  const text = await response.text();
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {
+      ok: response.ok,
+      status: response.status,
+      raw: text,
+    };
+  }
+}
+
 export async function runDevSendTest({
   request_url = "http://localhost/api/dev/send-test",
   insertSupabaseSendQueueRowImpl = insertSupabaseSendQueueRow,
-  runSendQueueImpl = runSendQueue,
+  fetchImpl = fetch,
 } = {}) {
+  const request_url_object = getRequestUrl(request_url);
+  const to_phone_number = parsePhoneOverride(
+    request_url_object.searchParams.get("to"),
+    "+16127433952"
+  );
+  const from_phone_number = parsePhoneOverride(
+    request_url_object.searchParams.get("from"),
+    "+16128060495"
+  );
   const now = new Date().toISOString();
   const queue_key = `dev-send-test-${crypto.randomUUID()}`;
+  const message_body = "Test message from Supabase send_queue";
 
   const inserted = await insertSupabaseSendQueueRowImpl({
     queue_key,
@@ -27,32 +80,50 @@ export async function runDevSendTest({
     is_locked: false,
     retry_count: 0,
     max_retries: 3,
-    message_body: "🔥 DEV SEND TEST",
-    message_text: "🔥 DEV SEND TEST",
-    to_phone_number: "+16127433952",
-    from_phone_number: "+16128060495",
-    character_count: "🔥 DEV SEND TEST".length,
+    message_body,
+    message_text: message_body,
+    to_phone_number,
+    from_phone_number,
+    character_count: message_body.length,
     metadata: {
       source: "dev_send_test",
     },
   });
 
   const should_run_now =
-    new URL(request_url).searchParams.get("run_now") !== "false";
+    request_url_object.searchParams.get("run_now") !== "false";
 
-  const run_result = should_run_now
-    ? await runSendQueueImpl({
-        limit: 50,
-      })
+  const queue_run = should_run_now
+    ? await parseQueueRunResponse(
+        await fetchImpl(buildQueueRunUrl(request_url), {
+          method: "GET",
+          headers: buildQueueRunHeaders(),
+        })
+      )
     : null;
 
   return {
     ok: inserted?.ok !== false,
     inserted,
-    run_result,
+    queue_run,
   };
 }
 
+export async function handleDevSendTestRequest(request, deps = {}) {
+  return Response.json(
+    await runDevSendTest({
+      request_url: request.url,
+      insertSupabaseSendQueueRowImpl:
+        deps.insertSupabaseSendQueueRowImpl || insertSupabaseSendQueueRow,
+      fetchImpl: deps.fetchImpl || fetch,
+    })
+  );
+}
+
 export async function GET(request) {
-  return Response.json(await runDevSendTest({ request_url: request.url }));
+  return handleDevSendTestRequest(request);
+}
+
+export async function POST(request) {
+  return GET(request);
 }

--- a/src/app/api/dev/send-test/route.js
+++ b/src/app/api/dev/send-test/route.js
@@ -1,0 +1,58 @@
+import crypto from "node:crypto";
+
+import { runSendQueue } from "@/lib/domain/queue/run-send-queue.js";
+import { insertSupabaseSendQueueRow } from "@/lib/supabase/sms-engine.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function runDevSendTest({
+  request_url = "http://localhost/api/dev/send-test",
+  insertSupabaseSendQueueRowImpl = insertSupabaseSendQueueRow,
+  runSendQueueImpl = runSendQueue,
+} = {}) {
+  const now = new Date().toISOString();
+  const queue_key = `dev-send-test-${crypto.randomUUID()}`;
+
+  const inserted = await insertSupabaseSendQueueRowImpl({
+    queue_key,
+    queue_id: queue_key,
+    queue_status: "queued",
+    scheduled_for: now,
+    scheduled_for_utc: now,
+    scheduled_for_local: now,
+    timezone: "America/Chicago",
+    contact_window: "8:00 AM - 9:00 PM",
+    send_priority: 10,
+    is_locked: false,
+    retry_count: 0,
+    max_retries: 3,
+    message_body: "🔥 DEV SEND TEST",
+    message_text: "🔥 DEV SEND TEST",
+    to_phone_number: "+16127433952",
+    from_phone_number: "+16128060495",
+    character_count: "🔥 DEV SEND TEST".length,
+    metadata: {
+      source: "dev_send_test",
+    },
+  });
+
+  const should_run_now =
+    new URL(request_url).searchParams.get("run_now") !== "false";
+
+  const run_result = should_run_now
+    ? await runSendQueueImpl({
+        limit: 50,
+      })
+    : null;
+
+  return {
+    ok: inserted?.ok !== false,
+    inserted,
+    run_result,
+  };
+}
+
+export async function GET(request) {
+  return Response.json(await runDevSendTest({ request_url: request.url }));
+}

--- a/src/app/api/internal/queue/run/route.js
+++ b/src/app/api/internal/queue/run/route.js
@@ -12,6 +12,7 @@ const logger = child({
 });
 
 export async function GET(request) {
+  console.log("QUEUE ROUTE HIT");
   return handleQueueRunRequest(request, "GET", {
     logger,
     jsonResponse: NextResponse.json,
@@ -19,8 +20,5 @@ export async function GET(request) {
 }
 
 export async function POST(request) {
-  return handleQueueRunRequest(request, "POST", {
-    logger,
-    jsonResponse: NextResponse.json,
-  });
+  return GET(request);
 }

--- a/src/app/api/internal/verification/replay/route.js
+++ b/src/app/api/internal/verification/replay/route.js
@@ -7,7 +7,7 @@ import { handleTextgridDeliveryWebhook } from "@/lib/flows/handle-textgrid-deliv
 import { handleDocusignWebhook } from "@/lib/domain/contracts/handle-docusign-webhook.js";
 import { handleTitleResponseWebhook } from "@/lib/domain/title/handle-title-response-webhook.js";
 import { handleClosingResponseWebhook } from "@/lib/domain/closings/handle-closing-response-webhook.js";
-import { processSendQueueItem } from "@/lib/domain/queue/process-send-queue.js";
+import { processSendQueue } from "@/lib/domain/queue/process-send-queue.js";
 import { queueOutboundMessage } from "@/lib/flows/queue-outbound-message.js";
 
 export const runtime = "nodejs";
@@ -26,7 +26,9 @@ async function replayQueueSend(payload = {}) {
     };
   }
 
-  return processSendQueueItem(queue_item_id);
+  return processSendQueue({
+    queue_item_id,
+  });
 }
 
 const FLOW_HANDLERS = {

--- a/src/app/api/webhooks/textgrid/inbound/route.js
+++ b/src/app/api/webhooks/textgrid/inbound/route.js
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server.js";
 
 import { maybeHandleBuyerTextgridInbound } from "@/lib/domain/buyers/handle-buyer-response-webhook.js";
 import { child } from "@/lib/logging/logger.js";
+import { hasSupabaseConfig } from "@/lib/supabase/client.js";
+import {
+  logInboundMessageEvent as logSupabaseInboundMessageEvent,
+  writeWebhookLog,
+} from "@/lib/supabase/sms-engine.js";
 import { handleTextgridInbound } from "@/lib/flows/handle-textgrid-inbound.js";
 import {
   buildTextgridWebhookBypassResult,
@@ -25,6 +30,8 @@ const defaultDeps = {
   handleTextgridInboundImpl: handleTextgridInbound,
   verifyTextgridWebhookRequestImpl: verifyTextgridWebhookRequest,
   normalizeTextgridInboundPayloadImpl: normalizeTextgridInboundPayload,
+  writeWebhookLogImpl: writeWebhookLog,
+  logSupabaseInboundMessageEventImpl: logSupabaseInboundMessageEvent,
 };
 
 let runtimeDeps = { ...defaultDeps };
@@ -565,6 +572,37 @@ export async function POST(request) {
         );
       }
       accepted_logged = true;
+
+      if (hasSupabaseConfig()) {
+        try {
+          await runtimeDeps.writeWebhookLogImpl({
+            event_type: payload.header_event || "inbound",
+            direction: "inbound",
+            provider_message_sid: payload.message_id || null,
+            payload,
+            headers: Object.fromEntries(request.headers.entries()),
+            received_at: new Date().toISOString(),
+            source: "textgrid",
+          });
+          await runtimeDeps.logSupabaseInboundMessageEventImpl(payload, {
+            now: new Date().toISOString(),
+          });
+        } catch (supabase_error) {
+          safeRouteLog(
+            "error",
+            "textgrid_inbound.supabase_logging_failed",
+            buildTextgridWebhookLogMeta({
+              payload,
+              webhook_verification,
+              downstream_handler_invoked,
+              podio_persistence_attempted,
+              extra: {
+                message: supabase_error?.message || "Unknown Supabase inbound logging error",
+              },
+            })
+          );
+        }
+      }
 
       if (inbound_debug_stage === "after_accepted") {
         return NextResponse.json({ ok: true, stage: "after_accepted" });

--- a/src/lib/domain/queue/build-send-queue-item.js
+++ b/src/lib/domain/queue/build-send-queue-item.js
@@ -1059,6 +1059,7 @@ export async function buildSendQueueItem({
       timezone: resolved_timezone || "America/Chicago",
       contact_window: contact_window_field.omitted ? null : resolved_contact_window,
       send_priority: mapPriorityToNumber(send_priority),
+      is_locked: false,
       retry_count: 0,
       max_retries: Number(max_retries) || 3,
       message_body: message_text || "",

--- a/src/lib/domain/queue/build-send-queue-item.js
+++ b/src/lib/domain/queue/build-send-queue-item.js
@@ -17,6 +17,8 @@ import {
   shouldAllowRawCategoryCompatibilityValue,
 } from "@/lib/podio/schema.js";
 import { normalizePhone } from "@/lib/providers/textgrid.js";
+import { hasSupabaseConfig } from "@/lib/supabase/client.js";
+import { insertSupabaseSendQueueRow } from "@/lib/supabase/sms-engine.js";
 import { resolveTemplateFieldReference } from "@/lib/domain/templates/template-reference.js";
 import { deriveQueueCurrentStage } from "@/lib/domain/communications-engine/state-machine.js";
 import { warn } from "@/lib/logging/logger.js";
@@ -202,6 +204,13 @@ function normalizePriority(value) {
   if (["_ urgent", "urgent", "high"].includes(raw)) return "_ Urgent";
   if (["_ low", "low"].includes(raw)) return "_ Low";
   return "_ Normal";
+}
+
+function mapPriorityToNumber(value) {
+  const normalized = normalizePriority(value).toLowerCase();
+  if (normalized === "_ urgent") return 10;
+  if (normalized === "_ low") return 1;
+  return 5;
 }
 
 function normalizeMessageType(value) {
@@ -1030,6 +1039,135 @@ export async function buildSendQueueItem({
       delete fields[key];
     }
   });
+
+  const use_supabase_queue_write =
+    hasSupabaseConfig() &&
+    create_item === createItem &&
+    update_item === updateItem;
+
+  if (use_supabase_queue_write) {
+    const resolved_queue_key =
+      clean(queue_id) || `queue-${phone_item_id}-${Date.now()}`;
+    const supabase_result = await insertSupabaseSendQueueRow({
+      queue_key: resolved_queue_key,
+      queue_id: resolved_queue_key,
+      queue_status: normalizeQueueStatus(queue_status).toLowerCase(),
+      scheduled_for: scheduled_utc_value?.start || scheduled_local_value?.start || nowIso(),
+      scheduled_for_utc: scheduled_utc_value?.start || scheduled_local_value?.start || nowIso(),
+      scheduled_for_local:
+        scheduled_local_value?.start || scheduled_utc_value?.start || nowIso(),
+      timezone: resolved_timezone || "America/Chicago",
+      contact_window: contact_window_field.omitted ? null : resolved_contact_window,
+      send_priority: mapPriorityToNumber(send_priority),
+      retry_count: 0,
+      max_retries: Number(max_retries) || 3,
+      message_body: message_text || "",
+      message_text: message_text || "",
+      to_phone_number: normalized_target,
+      from_phone_number: null,
+      property_address: property_address || null,
+      property_type: resolved_property_type || null,
+      owner_type: resolved_owner_type || null,
+      master_owner_id,
+      prospect_id,
+      property_id,
+      market_id,
+      sms_agent_id: assigned_agent_id || null,
+      textgrid_number_id: textgrid_number_item_id || null,
+      template_id:
+        template_reference.selected_template_id ??
+        template_reference.selected_template_item_id ??
+        template_id ??
+        null,
+      touch_number: next_touch_number,
+      dnc_check,
+      current_stage: resolved_current_stage || null,
+      message_type: normalized_message_type,
+      use_case_template: resolved_use_case_template || null,
+      personalization_tags_used: personalization_tags_used.length
+        ? personalization_tags_used
+        : null,
+      character_count: message_text ? countCharacters(message_text) : 0,
+      metadata: {
+        source: "build_send_queue_item",
+        selected_template_source: selected_template_source ?? null,
+        selected_template_item_id: template_reference.selected_template_item_id ?? null,
+        selected_template_id: template_reference.selected_template_id ?? null,
+        warnings: missing_relation_warnings,
+      },
+    });
+
+    return {
+      ok: supabase_result?.ok !== false,
+      queue_item_id: supabase_result?.queue_item_id || supabase_result?.item_id || null,
+      queue_id: supabase_result?.queue_id || resolved_queue_key,
+      queue_sequence: next_touch_number,
+      phone_item_id,
+      textgrid_number_item_id,
+      template_id,
+      selected_template_id: template_reference.selected_template_id ?? null,
+      selected_template_item_id: template_reference.selected_template_item_id ?? null,
+      selected_template_source: selected_template_source ?? null,
+      selected_template_title: template_reference.selected_template_title ?? null,
+      selected_template_use_case: template_reference.selected_template_use_case ?? null,
+      selected_template_variant_group:
+        template_reference.selected_template_variant_group ?? null,
+      selected_template_language: template_reference.selected_template_language ?? null,
+      selected_template_tone: template_reference.selected_template_tone ?? null,
+      selected_template_selection_diagnostics:
+        template_reference.selected_template_selection_diagnostics ?? null,
+      selected_template_resolution_source:
+        template_reference.selected_template_resolution_source ?? null,
+      selected_template_fallback_reason:
+        template_reference.selected_template_fallback_reason ?? null,
+      template_relation_id: null,
+      attempted_template_relation_id: template_reference.attached_template_id ?? null,
+      template_app_field_written: false,
+      template_attachment_strategy: "supabase_template_id",
+      template_attachment_reason: null,
+      template_target_app_ids: template_reference.target_app_ids || [],
+      template_relation_candidates: template_candidates.map(
+        (candidate) => candidate.attached_template_id
+      ),
+      template_attached: Boolean(
+        template_reference.selected_template_id ||
+          template_reference.selected_template_item_id ||
+          template_id
+      ),
+      message_text: message_text || null,
+      deferred_message_resolution: Boolean(defer_message_resolution && !message_text),
+      normalized_target,
+      touch_number: next_touch_number,
+      queue_status: normalizeQueueStatus(queue_status),
+      contact_window_written: !contact_window_field.omitted,
+      contact_window_omit_reason: contact_window_field.omitted
+        ? contact_window_field.reason
+        : null,
+      property_address_written: Boolean(property_id && property_address),
+      property_type_written: !property_type_field.omitted,
+      owner_type_written: !owner_type_field.omitted,
+      current_stage_written: !current_stage_field.omitted,
+      current_stage_value: resolved_current_stage,
+      use_case_template_written: !use_case_template_field.omitted,
+      message_type_value: normalized_message_type,
+      use_case_template_value: resolved_use_case_template,
+      strict_cold_outbound: Boolean(strict_cold_outbound),
+      warnings: [
+        ...missing_relation_warnings,
+        ...(defer_message_resolution && !message_text
+          ? ["Message text will be resolved during queue processing."]
+          : []),
+        ...(contact_window_field.omitted && contact_window_field.reason !== "empty"
+          ? [
+              `contact-window field omitted: no matching category option for "${resolved_contact_window}" in Send Queue schema.`,
+            ]
+          : []),
+      ],
+      raw: supabase_result?.raw || null,
+      storage: "supabase",
+      reason: supabase_result?.reason || null,
+    };
+  }
 
   let created = null;
   let template_attach_warning = null;

--- a/src/lib/domain/queue/process-send-queue.js
+++ b/src/lib/domain/queue/process-send-queue.js
@@ -242,7 +242,6 @@ function pickMessageFields(queue_row = {}) {
   return {
     to: clean(
       getQueueRowValue(queue_row, [
-        "to_number",
         "to_phone_number",
         "to",
         "phone",
@@ -251,7 +250,6 @@ function pickMessageFields(queue_row = {}) {
     ),
     from: clean(
       getQueueRowValue(queue_row, [
-        "from_number",
         "from_phone_number",
         "from",
         "selected_from_number",

--- a/src/lib/domain/queue/process-send-queue.js
+++ b/src/lib/domain/queue/process-send-queue.js
@@ -26,6 +26,7 @@ import {
   finalizeSendQueueSuccess,
   incrementTextgridNumberUsage,
   normalizeSendQueueRow,
+  normalizeQueueRowId,
   releaseSkippedQueueRow,
   reserveFromPhoneNumber,
   selectAvailableTextgridNumber,
@@ -180,14 +181,17 @@ function getNumberLike(record = null, key = "", fallback = null) {
 }
 
 function getQueueRowId(queue_row = null) {
-  return asPositiveInteger(
-    queue_row?.id ?? queue_row?.queue_item_id ?? queue_row?.item_id,
+  return normalizeQueueRowId(
+    queue_row?.queue_row_id ??
+      queue_row?.id ??
+      queue_row?.queue_item_id ??
+      queue_row?.item_id,
     null
   );
 }
 
 function isSupabaseQueueRow(queue_row = null) {
-  return Boolean(queue_row?.id) && !queue_row?.item_id;
+  return Boolean(getQueueRowId(queue_row)) && !Array.isArray(queue_row?.fields);
 }
 
 function getQueueRowValue(queue_row = null, keys = [], fallback = null) {
@@ -208,6 +212,36 @@ function getQueueRowValue(queue_row = null, keys = [], fallback = null) {
   }
 
   return fallback;
+}
+
+function buildSafeQueueRowShape(queue_row = null) {
+  return {
+    keys:
+      queue_row && typeof queue_row === "object" && !Array.isArray(queue_row)
+        ? Object.keys(queue_row).sort()
+        : [],
+    row: {
+      id: queue_row?.id ?? null,
+      queue_row_id: queue_row?.queue_row_id ?? null,
+      queue_item_id: queue_row?.queue_item_id ?? null,
+      item_id: queue_row?.item_id ?? null,
+      queue_key: queue_row?.queue_key ?? null,
+      queue_id: queue_row?.queue_id ?? null,
+      queue_status: queue_row?.queue_status ?? null,
+      lock_token_present: Boolean(clean(queue_row?.lock_token)),
+      has_message_body: Boolean(clean(queue_row?.message_body)),
+      has_message_text: Boolean(clean(queue_row?.message_text)),
+      has_to_phone_number: Boolean(clean(queue_row?.to_phone_number)),
+      has_from_phone_number: Boolean(clean(queue_row?.from_phone_number)),
+    },
+  };
+}
+
+function logMissingQueueRowId(queue_row = null, context = "queue_row_id_required") {
+  console.log("QUEUE ROW ID MISSING", {
+    context,
+    ...buildSafeQueueRowShape(queue_row),
+  });
 }
 
 function getQueueRowRelationId(queue_row = null, keys = [], fallback = null) {
@@ -308,7 +342,7 @@ async function updateQueueRow(queue_row_id, payload, deps = {}) {
 }
 
 export async function loadQueueRowById(queue_row_id, deps = {}) {
-  const resolved_id = asPositiveInteger(queue_row_id, null);
+  const resolved_id = normalizeQueueRowId(queue_row_id, null);
   if (!resolved_id) return null;
 
   if (typeof deps.loadQueueRowById === "function") {
@@ -671,7 +705,7 @@ export async function finalizeSuccessfulQueueSend(
   } = {},
   deps = {}
 ) {
-  const resolved_queue_row_id = asPositiveInteger(
+  const resolved_queue_row_id = normalizeQueueRowId(
     queue_item_id || getQueueRowId(queue_row),
     null
   );
@@ -847,6 +881,7 @@ async function processLegacyQueueItem(resolved_queue_row, deps = {}) {
   const send_textgrid_sms = deps.sendTextgridSMS || sendTextgridSMS;
 
   if (!queue_row_id) {
+    logMissingQueueRowId(resolved_queue_row, "processLegacyQueueItem");
     return {
       ok: false,
       sent: false,
@@ -1007,6 +1042,7 @@ async function processSupabaseQueueItem(resolved_queue_row, deps = {}) {
   let lock_token = clean(deps.claimedLockToken || queue_row?.lock_token) || null;
 
   if (!queue_row_id) {
+    logMissingQueueRowId(queue_row, "processSupabaseQueueItem");
     return {
       ok: false,
       sent: false,
@@ -1250,10 +1286,36 @@ async function processSupabaseQueueItem(resolved_queue_row, deps = {}) {
 }
 
 export async function processSendQueueItem(queue_row, deps = {}) {
-  const resolved_queue_row =
+  const looks_like_queue_row =
+    queue_row &&
+    typeof queue_row === "object" &&
+    !Array.isArray(queue_row) &&
+    Object.keys(queue_row).some(
+      (key) =>
+        [
+          "fields",
+          "queue_status",
+          "message_body",
+          "message_text",
+          "to_phone_number",
+          "from_phone_number",
+          "scheduled_for",
+          "scheduled_for_utc",
+          "scheduled_for_local",
+          "metadata",
+          "retry_count",
+          "max_retries",
+          "queue_key",
+          "queue_id",
+        ].includes(key)
+    );
+  const queue_row_id =
     queue_row && typeof queue_row === "object" && !Array.isArray(queue_row)
-      ? queue_row
-      : await loadQueueRowById(queue_row, deps);
+      ? getQueueRowId(queue_row)
+      : normalizeQueueRowId(queue_row, null);
+  const resolved_queue_row = looks_like_queue_row
+    ? queue_row
+    : await loadQueueRowById(queue_row_id, deps);
 
   if (!resolved_queue_row) {
     return {
@@ -1274,13 +1336,20 @@ export async function processSendQueue(input = {}, deps = {}) {
   const queue_row =
     input?.queue_row ||
     input?.row ||
-    (input && typeof input === "object" && input.id ? input : null);
+    (input &&
+    typeof input === "object" &&
+    (input.id || input.queue_row_id || input.queue_item_id || input.item_id)
+      ? input
+      : null);
 
   if (queue_row) {
     return processSendQueueItem(queue_row, deps);
   }
 
-  const queue_item_id = asPositiveInteger(input?.queue_item_id || input?.id, null);
+  const queue_item_id = normalizeQueueRowId(
+    input?.queue_row_id || input?.id || input?.queue_item_id || input,
+    null
+  );
   if (!queue_item_id) {
     return {
       ok: false,

--- a/src/lib/domain/queue/process-send-queue.js
+++ b/src/lib/domain/queue/process-send-queue.js
@@ -1,139 +1,61 @@
-// ─── process-send-queue.js ───────────────────────────────────────────────
-import APP_IDS from "@/lib/config/app-ids.js";
-
 import {
-  getItem,
-  getTextValue,
-  getCategoryValue,
-  getDateValue,
-  getFirstAppReferenceId,
-  getPhoneValue,
-  getNumberValue,
-  updateItem,
-  createMessageEvent,
-  PodioError,
-  isRevisionLimitExceeded,
-} from "@/lib/providers/podio.js";
-
-import {
-  sendTextgridSMS,
-  getTextgridSendEndpoint,
-  mapTextgridFailureBucket,
-  normalizePhone,
-} from "@/lib/providers/textgrid.js";
-
-import { validateActivePhone } from "@/lib/domain/compliance/validate-active-phone.js";
-import { shouldSuppressOutreach } from "@/lib/domain/compliance/should-suppress-outreach.js";
-import { isNegativeReply } from "@/lib/domain/classification/is-negative-reply.js";
-import { loadRecentEvents } from "@/lib/domain/context/load-recent-events.js";
-import { validateSendQueueItem } from "@/lib/domain/queue/validate-send-queue-item.js";
-import { logOutboundMessageEvent } from "@/lib/domain/events/log-outbound-message-event.js";
-import {
-  buildQueueClientReferenceId,
   buildQueueMessageEventMetadata,
   buildQueueSendFailedTriggerName,
 } from "@/lib/domain/events/message-event-metadata.js";
-import { updateBrainAfterSend } from "@/lib/domain/brain/update-brain-after-send.js";
-import { updateMasterOwnerAfterSend } from "@/lib/domain/master-owners/update-master-owner-after-send.js";
-import { linkMessageEventToBrain } from "@/lib/domain/brain/link-message-event-to-brain.js";
-import { resolveRoute } from "@/lib/domain/routing/resolve-route.js";
-import { loadTemplate } from "@/lib/domain/templates/load-template.js";
-import { renderTemplate } from "@/lib/domain/templates/render-template.js";
-import { loadRecentTemplates } from "@/lib/domain/context/load-recent-templates.js";
-import { deriveContextSummary } from "@/lib/domain/context/derive-context-summary.js";
-import { resolvePreferredContactLanguage } from "@/lib/domain/context/resolve-preferred-language.js";
-import { buildTemplateSelectorInput } from "@/lib/domain/templates/template-selector.js";
-import { findPropertyItems } from "@/lib/podio/apps/properties.js";
-import { normalizeTemplateItem } from "@/lib/podio/apps/templates.js";
-import { TEXTGRID_NUMBER_FIELDS } from "@/lib/podio/apps/textgrid-numbers.js";
-import { findBestBrainMatch } from "@/lib/podio/apps/ai-conversation-brain.js";
-import { normalizeForQueueText } from "@/lib/domain/queue/build-send-queue-item.js";
-import { resolveTemplateFieldReference } from "@/lib/domain/templates/template-reference.js";
-import {
-  deriveCanonicalSellerFlowFromTemplate,
-  inferCanonicalUseCaseFromOutboundText,
-  canonicalStageForUseCase,
-  normalizeSellerFlowTone,
-} from "@/lib/domain/seller-flow/canonical-seller-flow.js";
-import {
-  collapseConversationStageToLegacy,
-  deriveQueueCurrentStage,
-} from "@/lib/domain/communications-engine/state-machine.js";
+import { logOutboundMessageEvent } from "@/lib/domain/events/log-outbound-message-event.js";
 import {
   buildBaseSellerMessageEventFields,
   buildFailedMessageEventKey,
 } from "@/lib/domain/events/seller-message-event.js";
-
+import { updateBrainAfterSend } from "@/lib/domain/brain/update-brain-after-send.js";
+import { updateMasterOwnerAfterSend } from "@/lib/domain/master-owners/update-master-owner-after-send.js";
 import { info, warn } from "@/lib/logging/logger.js";
+import {
+  mapTextgridFailureBucket,
+  normalizePhone,
+  sendTextgridSMS,
+} from "@/lib/providers/textgrid.js";
+import {
+  hasSupabaseConfig,
+  supabase as defaultSupabase,
+} from "@/lib/supabase/client.js";
+import {
+  claimSendQueueRow,
+  evaluateContactWindow,
+  finalizeSendQueueFailure,
+  finalizeSendQueueSuccess,
+  incrementTextgridNumberUsage,
+  normalizeSendQueueRow,
+  releaseSkippedQueueRow,
+  reserveFromPhoneNumber,
+  selectAvailableTextgridNumber,
+  writeOutboundFailureMessageEvent,
+  writeOutboundSuccessMessageEvent,
+} from "@/lib/supabase/sms-engine.js";
 
-const QUEUE_FIELDS = {
-  queue_status: "queue-status",
-  scheduled_for_local: "scheduled-for-local",
-  scheduled_for_utc: "scheduled-for-utc",
-  timezone: "timezone",
-  send_priority: "send-priority",
-  retry_count: "retry-count",
-  max_retries: "max-retries",
+const QUEUE_TABLE = "send_queue";
 
-  master_owner: "master-owner",
-  prospects: "prospects",
-  properties: "properties",
-  phone_number: "phone-number",
-  market: "market",
-  sms_agent: "sms-agent",
-  textgrid_number: "textgrid-number",
-  template: "template-2",
-
-  message_type: "message-type",
-  message_text: "message-text",
-  personalization_tags_used: "personalization-tags-used",
-  character_count: "character-count",
-
-  sent_at: "sent-at",
-  delivered_at: "delivered-at",
-  failed_reason: "failed-reason",
-  delivery_confirmed: "delivery-confirmed",
-  property_address: "property-address",
+const TEXTGRID_NUMBER_FIELDS = {
+  title: "title",
+  status: "status",
+  hard_pause: "hard-pause",
+  pause_until: "pause-until",
 };
 
-const EVENT_FIELDS = {
-  message_id: "message-id",
-  provider_message_sid: "text-2",
-  timestamp: "timestamp",
-  direction: "direction",
-  event_type: "category",
-  message_variant: "message-variant",
-  master_owner: "master-owner",
-  prospect: "linked-seller",
-  property: "property",
-  textgrid_number: "textgrid-number",
-  phone_number: "phone-number",
-  conversation: "conversation",
-  market: "market",
-  ai_route: "ai-route",
-  processed_by: "processed-by",
-  source_app: "source-app",
-  trigger_name: "trigger-name",
-  message: "message",
-  template: "template",
-  character_count: "character-count",
-  delivery_status: "status-3",
-  raw_carrier_status: "status-2",
-  latency_ms: "latency-ms",
-  failure_bucket: "failure-bucket",
-  is_final_failure: "is-final-failure",
-  ai_output: "ai-output",
-};
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function lower(value) {
+  return clean(value).toLowerCase();
+}
 
 function nowIso() {
   return new Date().toISOString();
 }
 
-// Returns current time as "YYYY-MM-DD HH:MM:SS" in America/Chicago for
-// operational Podio date fields (Sent At).  Podio stores the string as-is so
-// ops sees Central hours rather than UTC.
-function nowPodioDateTimeCentral(value = null) {
-  const now = value ? new Date(value) : new Date();
+function nowPodioDateTimeCentral(value = nowIso()) {
+  const now = new Date(value);
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: "America/Chicago",
     year: "numeric",
@@ -144,31 +66,26 @@ function nowPodioDateTimeCentral(value = null) {
     second: "2-digit",
     hour12: false,
   }).formatToParts(now);
-  const get = (type) => parts.find((p) => p.type === type)?.value ?? "00";
+  const get = (type) => parts.find((part) => part.type === type)?.value ?? "00";
   return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}:${get("second")}`;
 }
 
-function clean(value) {
-  return String(value ?? "").trim();
+function asPositiveInteger(value, fallback = null) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : fallback;
 }
 
-function toTimestamp(value) {
-  if (!value) return null;
-  const ts = new Date(value).getTime();
-  return Number.isNaN(ts) ? null : ts;
-}
-
-function lower(value) {
-  return clean(value).toLowerCase();
+function asNonNegativeInteger(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.trunc(parsed) : fallback;
 }
 
 function asArrayAppRef(value) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? [parsed] : undefined;
+  const parsed = asPositiveInteger(value, null);
+  return parsed ? [parsed] : undefined;
 }
 
 function isPositiveCategory(value) {
-  const raw = lower(value);
   return [
     "yes",
     "true",
@@ -178,11 +95,10 @@ function isPositiveCategory(value) {
     "on",
     "_ active",
     "_ warming up",
-  ].includes(raw);
+  ].includes(lower(value));
 }
 
 function isNegativeCategory(value) {
-  const raw = lower(value);
   return [
     "no",
     "false",
@@ -194,732 +110,364 @@ function isNegativeCategory(value) {
     "_ paused",
     "_ flagged",
     "⚫ retired",
-  ].includes(raw);
+  ].includes(lower(value));
 }
 
-function shouldRetryQueueUpdateWithoutTemplate(error) {
-  if (!(error instanceof PodioError)) return false;
-  // Revision-limit errors must NOT be retried — the item cannot be written to at all.
-  if (isRevisionLimitExceeded(error)) return false;
+function getSupabase(deps = {}) {
+  if (!deps.supabase && !deps.supabaseClient && !hasSupabaseConfig()) {
+    throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  }
+  return deps.supabase || deps.supabaseClient || defaultSupabase;
+}
 
-  const message = clean(error?.message).toLowerCase();
-  return (
-    error.status === 400 &&
-    (
-      message.includes("template") ||
-      message.includes("referenced") ||
-      message.includes("item") ||
-      message.includes("value")
-    )
+function getPlainValue(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== "object") return raw;
+  if ("value" in raw) {
+    const value = raw.value;
+    if (value && typeof value === "object" && "text" in value) return value.text;
+    if (value && typeof value === "object" && "item_id" in value) return value.item_id;
+    return value;
+  }
+  if ("start" in raw) return raw.start;
+  if ("text" in raw) return raw.text;
+  if ("item_id" in raw) return raw.item_id;
+  return raw;
+}
+
+function getRecordFieldValues(record = null, key = "") {
+  if (!record || typeof record !== "object") return [];
+
+  if (Object.prototype.hasOwnProperty.call(record, key)) {
+    const direct = record[key];
+    return Array.isArray(direct) ? direct : [direct];
+  }
+
+  const fields = Array.isArray(record.fields) ? record.fields : [];
+  const matched = fields.find((field) => clean(field?.external_id) === clean(key));
+  if (!matched) return [];
+  return Array.isArray(matched.values) ? matched.values : [];
+}
+
+function getTextLike(record = null, key = "", fallback = null) {
+  const values = getRecordFieldValues(record, key);
+  if (!values.length) return fallback;
+  const raw = getPlainValue(values[0]);
+  return clean(raw) || fallback;
+}
+
+function getCategoryLike(record = null, key = "", fallback = null) {
+  const values = getRecordFieldValues(record, key);
+  if (!values.length) return fallback;
+  const first = values[0];
+  if (first?.value?.text) return clean(first.value.text) || fallback;
+  const raw = getPlainValue(first);
+  return clean(raw) || fallback;
+}
+
+function getDateLike(record = null, key = "", fallback = null) {
+  const values = getRecordFieldValues(record, key);
+  if (!values.length) return fallback;
+  const raw = values[0]?.start ?? getPlainValue(values[0]);
+  return clean(raw) || fallback;
+}
+
+function getNumberLike(record = null, key = "", fallback = null) {
+  const values = getRecordFieldValues(record, key);
+  if (!values.length) return fallback;
+  const raw = Number(getPlainValue(values[0]));
+  return Number.isFinite(raw) ? raw : fallback;
+}
+
+function getQueueRowId(queue_row = null) {
+  return asPositiveInteger(
+    queue_row?.id ?? queue_row?.queue_item_id ?? queue_row?.item_id,
+    null
   );
 }
 
-async function updateQueueItemWithTemplateCandidates({
-  queue_item_id,
-  base_payload,
-  template_reference,
-}) {
-  const template_candidates = template_reference?.attachment_candidates || [];
-  let template_attach_rejected = false;
+function isSupabaseQueueRow(queue_row = null) {
+  return Boolean(queue_row?.id) && !queue_row?.item_id;
+}
 
-  if (!template_candidates.length) {
-    await updateItem(queue_item_id, base_payload);
-    return {
-      selected_template_candidate: null,
-      template_attach_rejected,
-    };
-  }
-
-  for (const candidate of template_candidates) {
-    const attempt_payload = {
-      ...base_payload,
-      [QUEUE_FIELDS.template]: candidate.field_value,
-    };
-
-    try {
-      await updateItem(queue_item_id, attempt_payload);
-      return {
-        selected_template_candidate: candidate,
-        template_attach_rejected: false,
-      };
-    } catch (error) {
-      logRevisionLimitPhase(queue_item_id, "resolve_deferred_message", "template_write", error);
-      if (!shouldRetryQueueUpdateWithoutTemplate(error)) {
-        throw error;
+function getQueueRowValue(queue_row = null, keys = [], fallback = null) {
+  for (const key of keys) {
+    if (queue_row && Object.prototype.hasOwnProperty.call(queue_row, key)) {
+      const value = queue_row[key];
+      if (value !== null && value !== undefined && clean(value) !== "") {
+        return value;
       }
-
-      template_attach_rejected = true;
     }
   }
 
-  await updateItem(queue_item_id, base_payload);
-  return {
-    selected_template_candidate: null,
-    template_attach_rejected,
-  };
-}
-
-function logRevisionLimitPhase(queue_item_id, operation, phase, err) {
-  if (!isRevisionLimitExceeded(err)) return;
-  warn("queue.process_revision_limit_at_phase", {
-    queue_item_id,
-    operation,
-    phase,
-    failure_bucket: "revision_limit_exceeded",
-    skipped: true,
-    message: err?.message || null,
-  });
-}
-
-function getTouchNumber(queue_item) {
-  const touch_number = Number(getNumberValue(queue_item, "touch-number", 1) || 1);
-  return Number.isFinite(touch_number) && touch_number > 0 ? touch_number : 1;
-}
-
-function deriveOwnerTouchCountFromQueue(queue_item) {
-  return Math.max(0, getTouchNumber(queue_item) - 1);
-}
-
-const FOLLOW_UP_CONTACT_STATUSES = new Set([
-  "contacted",
-  "engaged",
-  "offer sent",
-  "negotiating",
-]);
-
-const FOLLOW_UP_CONTACT_STATUS_2 = new Set([
-  "sent",
-  "received",
-  "follow-up scheduled",
-]);
-
-function deriveOwnerStageHint(owner_item) {
-  const contact_status = lower(getCategoryValue(owner_item, "contact-status", null));
-  const contact_status_2 = lower(getCategoryValue(owner_item, "contact-status-2", null));
-  const has_offer = Boolean(getFirstAppReferenceId(owner_item, "offer", null));
-
-  if (has_offer || ["offer sent", "negotiating"].includes(contact_status)) {
-    return "Offer";
+  for (const key of keys) {
+    const text = getTextLike(queue_row, key, null);
+    if (text !== null && text !== undefined && clean(text) !== "") {
+      return text;
+    }
   }
 
-  if (
-    FOLLOW_UP_CONTACT_STATUSES.has(contact_status) ||
-    FOLLOW_UP_CONTACT_STATUS_2.has(contact_status_2)
-  ) {
-    return "Follow-Up";
-  }
-
-  return "Ownership";
-}
-
-function deriveOwnerEmotion(owner_item) {
-  const urgency = Number(getNumberValue(owner_item, "urgency-score", 0) || 0);
-  const financial_pressure = Number(
-    getNumberValue(owner_item, "financial-pressure-score", 0) || 0
-  );
-  const tax_delinquent = Number(
-    getNumberValue(owner_item, "portfolio-tax-delinquent-count", 0) || 0
-  );
-  const lien_count = Number(getNumberValue(owner_item, "portfolio-lien-count", 0) || 0);
-
-  if (
-    urgency >= 80 ||
-    financial_pressure >= 80 ||
-    tax_delinquent > 0 ||
-    lien_count > 0
-  ) {
-    return "motivated";
-  }
-
-  return "curious";
-}
-
-function deriveTemplatePrimaryCategory(property_item, owner_item, fallback = "Residential") {
-  const property_class = getCategoryValue(property_item, "property-class", null);
-  if (property_class) return property_class;
-
-  const majority = clean(getCategoryValue(owner_item, "property-type-majority", null)).toUpperCase();
-  if (majority === "VACANT LAND") return "Vacant";
-  return fallback || "Residential";
-}
-
-function deriveTemplateSecondaryCategory(property_item, owner_item, fallback = null) {
   return fallback;
 }
 
-function deriveSequencePosition(stage, owner_touch_count) {
-  const normalized_stage = collapseConversationStageToLegacy(stage, stage);
-  const touch_number = Math.max(1, Number(owner_touch_count || 0) + 1);
-
-  if (normalized_stage === "Offer") {
-    if (touch_number <= 1) return "V1";
-    if (touch_number === 2) return "V2";
-    return "V3";
-  }
-
-  if (touch_number <= 1) return "1st Touch";
-  if (touch_number === 2) return "2nd Touch";
-  if (touch_number === 3) return "3rd Touch";
-  if (touch_number === 4) return "4th Touch";
-  return "Final";
-}
-
-async function safeGetItem(item_id) {
-  if (!item_id) return null;
-  try {
-    return await getItem(item_id);
-  } catch (error) {
-    warn("queue.deferred_context_item_failed", {
-      item_id,
-      message: error?.message || "Unknown item fetch error",
-    });
-    return null;
-  }
-}
-
-function buildDeferredQueueContext({
-  phone_item,
-  brain_item,
-  master_owner_item,
-  prospect_item = null,
-  property_item,
-  market_item,
-  agent_item,
-  touch_count,
-}) {
-  const recent_templates = loadRecentTemplates({
-    brain_item,
-    limit: 10,
-  });
-
-  return {
-    found: true,
-    ids: {
-      brain_item_id: brain_item?.item_id ?? null,
-      phone_item_id: phone_item?.item_id ?? null,
-      master_owner_id: master_owner_item?.item_id ?? null,
-      prospect_id:
-        prospect_item?.item_id ??
-        getFirstAppReferenceId(phone_item, "linked-contact", null),
-      property_id: property_item?.item_id ?? null,
-      market_id: market_item?.item_id ?? null,
-      assigned_agent_id: agent_item?.item_id ?? null,
-    },
-    items: {
-      phone_item,
-      brain_item,
-      master_owner_item,
-      prospect_item,
-      property_item,
-      market_item,
-      agent_item,
-    },
-    summary: deriveContextSummary({
-      phone_item,
-      brain_item,
-      master_owner_item,
-      prospect_item,
-      property_item,
-      agent_item,
-      market_item,
-      touch_count,
-    }),
-    recent: {
-      touch_count,
-      last_template_id: recent_templates.last_template_id,
-      recently_used_template_ids: recent_templates.recent_template_ids,
-    },
-  };
-}
-
-async function resolveDeferredQueueMessage(queue_item, { queue_item_id, phone_item, brain_item } = {}) {
-  const existing_message_text = clean(getTextValue(queue_item, QUEUE_FIELDS.message_text, ""));
-  const existing_template_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.template, null);
-
-  if (existing_message_text) {
-    return {
-      ok: true,
-      deferred: false,
-      message_text: existing_message_text,
-      template_id: existing_template_id,
-      template_relation_id: existing_template_id,
-      selected_template_id: existing_template_id,
-      selected_template_source: null,
-      selected_template_title: null,
-      template_app_field_written: Boolean(existing_template_id),
-      template_attached: Boolean(existing_template_id),
-      selected_template_resolution_source: Boolean(existing_template_id)
-        ? "existing_queue_template_relation"
-        : null,
-      selected_template_fallback_reason: null,
-      queue_item,
-    };
-  }
-
-  const master_owner_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.master_owner, null);
-  if (!master_owner_id) {
-    return {
-      ok: false,
-      reason: "empty_message_body",
-      details: {
-        deferred_resolution_supported: false,
-      },
-    };
-  }
-
-  const touch_count = deriveOwnerTouchCountFromQueue(queue_item);
-  const property_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.properties, null);
-  const market_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.market, null);
-  const sms_agent_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.sms_agent, null);
-  const prospect_id =
-    getFirstAppReferenceId(queue_item, QUEUE_FIELDS.prospects, null) ||
-    getFirstAppReferenceId(phone_item, "linked-contact", null) ||
-    null;
-
-  warn("queue.deferred_resolution_legacy_path", {
-    queue_item_id,
-    master_owner_id,
-    message: "Queue item missing pre-rendered message_text — falling back to legacy deferred resolution. New SMS engine pipeline should pre-render all messages at queue-creation time.",
-  });
-
-  info("queue.message_resolution_started", {
-    queue_item_id,
-    master_owner_id,
-    touch_count,
-  });
-
-  const started_at = Date.now();
-
-  const [master_owner_item, prospect_item, queued_property_item, queued_market_item, agent_item] = await Promise.all([
-    safeGetItem(master_owner_id),
-    safeGetItem(prospect_id),
-    safeGetItem(property_id),
-    safeGetItem(market_id),
-    safeGetItem(sms_agent_id),
-  ]);
-  let property_item =
-    queued_property_item ||
-    // Also check the brain item's properties relation before falling back to a lookup
-    (brain_item ? await safeGetItem(getFirstAppReferenceId(brain_item, "properties", null)) : null);
-
-  if (!property_item?.item_id && master_owner_id) {
-    try {
-      const response = await findPropertyItems({ "linked-master-owner": master_owner_id }, 1, 0);
-      property_item = response?.items?.[0] ?? response?.[0] ?? null;
-    } catch (_error) {
-      property_item = null;
+function getQueueRowRelationId(queue_row = null, keys = [], fallback = null) {
+  for (const key of keys) {
+    if (queue_row && Object.prototype.hasOwnProperty.call(queue_row, key)) {
+      const value = asPositiveInteger(queue_row[key], null);
+      if (value) return value;
     }
   }
 
-  if (!property_item?.item_id) {
-    warn("queue.deferred_message_property_not_found", {
-      queue_item_id,
-      master_owner_id,
-      queued_property_id: property_id || null,
-      message: "No property item resolved for deferred message — property_address may be missing",
-    });
+  for (const key of keys) {
+    const values = getRecordFieldValues(queue_row, key);
+    if (!values.length) continue;
+    const raw = values[0]?.value?.item_id ?? getPlainValue(values[0]);
+    const parsed = asPositiveInteger(raw, null);
+    if (parsed) return parsed;
   }
 
-  const derived_market_id =
-    queued_market_item?.item_id ??
-    getFirstAppReferenceId(property_item, "market-2", null) ??
-    getFirstAppReferenceId(property_item, "market", null) ??
-    null;
-  const market_item =
-    queued_market_item?.item_id && String(queued_market_item.item_id) === String(derived_market_id || "")
-      ? queued_market_item
-      : await safeGetItem(derived_market_id);
+  return fallback;
+}
 
-  const context = buildDeferredQueueContext({
-    phone_item,
-    brain_item,
-    master_owner_item,
-    prospect_item,
-    property_item,
-    market_item,
-    agent_item,
-    touch_count,
-  });
+function getConfirmedProviderMessageSid(send_result = {}) {
+  return (
+    clean(send_result?.sid) ||
+    clean(send_result?.message_id) ||
+    clean(send_result?.provider_message_id) ||
+    null
+  );
+}
 
-  const stage_hint = master_owner_item
-    ? deriveOwnerStageHint(master_owner_item)
-    : context.summary?.conversation_stage || "Ownership";
-  const language = resolvePreferredContactLanguage({
-    master_owner_item,
-    prospect_item,
-    brain_item,
-  });
-  const classification = {
-    message: "",
-    language,
-    objection: null,
-    emotion: master_owner_item ? deriveOwnerEmotion(master_owner_item) : "curious",
-    stage_hint,
-    compliance_flag: null,
-    positive_signals: [],
-    confidence: 1,
-    motivation_score:
-      getNumberValue(master_owner_item, "urgency-score", null) ??
-      getNumberValue(master_owner_item, "financial-pressure-score", null) ??
-      null,
-    source: "queue_processing",
-    notes: "deferred_template_resolution",
-    phone_activity_status: context.summary?.phone_activity_status || "Unknown",
+function pickMessageFields(queue_row = {}) {
+  return {
+    to: clean(
+      getQueueRowValue(queue_row, [
+        "to_number",
+        "to_phone_number",
+        "to",
+        "phone",
+        "recipient_phone",
+      ])
+    ),
+    from: clean(
+      getQueueRowValue(queue_row, [
+        "from_number",
+        "from_phone_number",
+        "from",
+        "selected_from_number",
+        "outbound_number_phone",
+      ])
+    ),
+    body: clean(
+      getQueueRowValue(queue_row, [
+        "message_body",
+        "body",
+        "message_text",
+        "rendered_message_text",
+      ])
+    ),
   };
+}
 
-  const route = resolveRoute({
-    classification,
-    brain_item,
-    phone_item,
-    message: "",
-  });
-
-  const primary_category = deriveTemplatePrimaryCategory(
-    property_item,
-    master_owner_item,
-    route?.primary_category || "Residential"
-  );
-  const secondary_category = deriveTemplateSecondaryCategory(
-    property_item,
-    master_owner_item,
-    route?.secondary_category || null
-  );
-  const sequence_position = deriveSequencePosition(route?.stage || stage_hint, touch_count);
-  const message_variant_seed = clean(
-    getCategoryValue(master_owner_item, "message-variant-seed", null)
-  );
-  const rotation_key = [
-    master_owner_id || "no-owner",
-    phone_item?.item_id || "no-phone",
-    property_item?.item_id || "no-property",
-    route?.use_case || "no-use-case",
-    route?.lifecycle_stage || route?.stage || stage_hint || "no-stage",
-    message_variant_seed || "no-seed",
-  ].join(":");
-  const resolved_message_type =
-    route?.stage === "Ownership" && touch_count <= 1 ? "Cold Outbound" : "Follow-Up";
-  const template_selector = buildTemplateSelectorInput({
-    template_selector: route?.template_selector || null,
-    use_case: route?.use_case || "ownership_check",
-    language,
-    touch_number: touch_count,
-    message_type: resolved_message_type,
-    category: primary_category,
-    secondary_category,
-    sequence_position,
-    route,
-    context,
-  });
-
-  const selected_template = await loadTemplate({
-    template_selector,
-    category: primary_category,
-    secondary_category,
-    use_case: route?.use_case || "ownership_check",
-    variant_group: route?.variant_group || "Stage 1 — Ownership Confirmation",
-    tone: route?.tone || "Warm",
-    gender_variant: "Neutral",
-    language,
-    sequence_position,
-    touch_type: template_selector.touch_type,
-    touch_number: touch_count,
-    message_type: resolved_message_type,
-    property_type_scope: template_selector.property_type_scope,
-    deal_strategy: template_selector.deal_strategy,
-    paired_with_agent_type:
-      route?.template_filters?.paired_with_agent_type || route?.persona || "Warm Professional",
-    recently_used_template_ids: context?.recent?.recently_used_template_ids || [],
-    rotation_key,
-    fallback_agent_type:
-      route?.template_filters?.fallback_agent_type || "Warm Professional",
-    allow_variant_group_fallback: true,
-  });
-
-  if (!selected_template?.item_id) {
-    return {
-      ok: false,
-      reason: "template_not_found",
-      details: {
-        route: {
-          stage: route?.stage || stage_hint,
-          lifecycle_stage: route?.lifecycle_stage || null,
-          use_case: route?.use_case || "ownership_check",
-          variant_group: route?.variant_group || "Stage 1 — Ownership Confirmation",
-          language,
-          template_selector,
-          tone: route?.tone || "Warm",
-          sequence_position,
-          category: primary_category,
-          secondary_category,
-        },
-      },
-    };
-  }
-
-  const render_result = renderTemplate({
-    template_text: selected_template.text,
-    context,
-    overrides: {
-      language,
-      conversation_stage: route?.stage || stage_hint,
-      lifecycle_stage: route?.lifecycle_stage || null,
-      ai_route: route?.brain_ai_route || context.summary?.brain_ai_route || null,
-    },
-  });
-
-  if (render_result?.missing_required_placeholders?.length || render_result?.invalid_placeholders?.length) {
-    warn("queue.deferred_message_placeholder_validation_failed", {
-      queue_item_id,
-      template_id: selected_template.item_id,
-      property_item_id: property_item?.item_id || null,
-      missing_required_placeholders: render_result.missing_required_placeholders || [],
-      invalid_placeholders: render_result.invalid_placeholders || [],
-    });
-    return {
-      ok: false,
-      reason: "template_placeholder_validation_failed",
-      details: {
-        template_id: selected_template.item_id,
-        missing_required_placeholders: render_result.missing_required_placeholders || [],
-        invalid_placeholders: render_result.invalid_placeholders || [],
-      },
-    };
-  }
-
-  // Use normalizeForQueueText (not clean) to collapse embedded newlines into
-  // spaces before writing to the Send Queue message-text field.  That field is
-  // a single-line Podio text field: passing a multiline string causes Podio to
-  // store only the first line, truncating the message to "Hi" / "Hola".
-  const rendered_message_text = normalizeForQueueText(render_result?.rendered_text || "");
-  if (!rendered_message_text) {
-    return {
-      ok: false,
-      reason: "rendered_message_empty",
-      details: {
-        template_id: selected_template.item_id,
-      },
-    };
-  }
-
-  const template_reference = resolveTemplateFieldReference({
-    host_app_id: APP_IDS.send_queue,
-    host_field_external_id: QUEUE_FIELDS.template,
-    template_id: selected_template.item_id,
-    template_item: selected_template,
-  });
-  const queue_resolution_payload = {
-    [QUEUE_FIELDS.message_text]: rendered_message_text,
-    [QUEUE_FIELDS.character_count]: rendered_message_text.length,
-    ...(render_result.used_placeholders?.length
-      ? { [QUEUE_FIELDS.personalization_tags_used]: render_result.used_placeholders }
-      : {}),
+function toFailureResult(queue_row = null, error = null) {
+  const queue_row_id = getQueueRowId(queue_row);
+  return {
+    ok: false,
+    sent: false,
+    queue_status: "failed",
+    reason: clean(error?.message) || "queue_processing_failed",
+    failed_reason: clean(error?.message) || "queue_processing_failed",
+    queue_row_id,
+    queue_item_id: queue_row_id,
   };
-  const {
-    selected_template_candidate,
-    template_attach_rejected,
-  } = await updateQueueItemWithTemplateCandidates({
-    queue_item_id,
-    base_payload: queue_resolution_payload,
-    template_reference,
-  });
+}
 
-  const refreshed_queue_item = await getItem(queue_item_id);
-  const template_relation_id =
-    getFirstAppReferenceId(refreshed_queue_item, QUEUE_FIELDS.template, null) || null;
-  const template_app_field_written =
-    Boolean(selected_template_candidate?.attached_template_id) &&
-    !template_attach_rejected &&
-    String(template_relation_id || "") ===
-      String(selected_template_candidate?.attached_template_id || "");
+async function updateQueueRow(queue_row_id, payload, deps = {}) {
+  if (!queue_row_id) {
+    throw new Error("missing_queue_row_id");
+  }
 
-  info("queue.message_resolution_completed", {
-    queue_item_id,
-    template_id: selected_template.item_id,
-    template_source: selected_template.source || null,
-    template_resolution_source:
-      selected_template.template_resolution_source || null,
-    template_fallback_reason:
-      selected_template.template_fallback_reason || null,
-    template_title: selected_template.title || null,
-    template_relation_id,
-    template_app_field_written,
-    template_attachment_strategy: template_attach_rejected
-      ? "podio_rejected_template_reference"
-      : selected_template_candidate?.attachment_strategy ||
-        template_reference.attachment_strategy,
-    template_attachment_reason: template_attach_rejected
-      ? "template_attach_rejected_by_podio"
-      : template_reference.attachment_reason,
-    duration_ms: Date.now() - started_at,
-    character_count: rendered_message_text.length,
-  });
+  if (typeof deps.updateQueueRow === "function") {
+    return deps.updateQueueRow(queue_row_id, payload);
+  }
+
+  if (typeof deps.updateItem === "function") {
+    return deps.updateItem(queue_row_id, payload);
+  }
+
+  const { error } = await getSupabase(deps)
+    .from(QUEUE_TABLE)
+    .update(payload)
+    .eq("id", queue_row_id);
+
+  if (error) throw error;
 
   return {
     ok: true,
-    deferred: true,
-    template_id: selected_template.item_id,
-    template_relation_id,
-    selected_template_id: selected_template.item_id,
-    selected_template_source: selected_template.source || null,
-    selected_template_title: selected_template.title || null,
-    selected_template_resolution_source:
-      selected_template.template_resolution_source || null,
-    selected_template_fallback_reason:
-      selected_template.template_fallback_reason || null,
-    template_app_field_written,
-    template_attached: template_app_field_written,
-    template_item: selected_template.raw || null,
-    canonical_flow: deriveCanonicalSellerFlowFromTemplate(selected_template),
-    message_text: rendered_message_text,
-    queue_item: refreshed_queue_item || queue_item,
-    route,
+    id: queue_row_id,
+    payload,
   };
 }
 
-async function resolveCanonicalSellerFlowForQueue({
-  template_id = null,
-  template_item = null,
-  message_body = "",
-} = {}) {
-  let candidate_template = template_item || null;
+export async function loadQueueRowById(queue_row_id, deps = {}) {
+  const resolved_id = asPositiveInteger(queue_row_id, null);
+  if (!resolved_id) return null;
 
-  if (!candidate_template && template_id) {
-    candidate_template = await safeGetItem(template_id);
+  if (typeof deps.loadQueueRowById === "function") {
+    return deps.loadQueueRowById(resolved_id);
   }
 
-  if (candidate_template) {
-    const normalized_template =
-      candidate_template.raw && candidate_template.text
-        ? candidate_template
-        : normalizeTemplateItem(candidate_template);
-    const derived = deriveCanonicalSellerFlowFromTemplate(normalized_template);
-    if (derived) return derived;
+  const { data, error } = await getSupabase(deps)
+    .from(QUEUE_TABLE)
+    .select("*")
+    .eq("id", resolved_id)
+    .maybeSingle();
 
-    if (
-      clean(normalized_template?.use_case) ||
-      clean(normalized_template?.variant_group)
-    ) {
-      return {
-        selected_use_case: clean(normalized_template?.use_case) || null,
-        template_use_case: clean(normalized_template?.use_case) || null,
-        next_expected_stage: canonicalStageForUseCase(
-          clean(normalized_template?.use_case) || null
-        ),
-        selected_variant_group: clean(normalized_template?.variant_group) || null,
-        selected_tone: normalizeSellerFlowTone(normalized_template?.tone),
-      };
-    }
-  }
+  if (error) throw error;
 
-  const inferred_use_case = inferCanonicalUseCaseFromOutboundText(message_body);
-  if (!inferred_use_case) return null;
+  if (!data) return null;
 
-  return {
-    selected_use_case: inferred_use_case,
-    template_use_case: null,
-    next_expected_stage: canonicalStageForUseCase(inferred_use_case),
-    selected_variant_group: null,
-    selected_tone: null,
-  };
+  return isSupabaseQueueRow(data) ? normalizeSendQueueRow(data) : data;
 }
 
-function extractItemRevision(item = null) {
-  const revision =
-    item?.current_revision?.revision ??
-    item?.revision ??
-    null;
+async function markQueueRowSending(queue_row = {}, deps = {}) {
+  const queue_row_id = getQueueRowId(queue_row);
+  const retry_count = asNonNegativeInteger(queue_row?.retry_count, 0);
 
-  return Number.isFinite(Number(revision)) ? Number(revision) : null;
-}
-
-function mapFailureReasonToQueueCategory(send_result, fallback_bucket = null) {
-  const bucket = fallback_bucket || mapTextgridFailureBucket(send_result) || "Other";
-
-  if (bucket === "DNC") return "Opt-Out";
-  if (bucket === "Hard Bounce") return "Invalid Number";
-  if (bucket === "Soft Bounce") return "Network Error";
-  if (bucket === "Spam") return "Carrier Block";
-
-  const msg = String(send_result?.error_message || "").toLowerCase();
-  if (msg.includes("daily") && msg.includes("limit")) return "Daily Limit Hit";
-
-  return "Network Error";
-}
-
-async function resolveBrainForQueue({
-  phone_item_id = null,
-  master_owner_id = null,
-  prospect_id = null,
-}) {
-  return findBestBrainMatch({
-    phone_item_id,
-    prospect_id,
-    master_owner_id,
-  });
-}
-
-async function resolveQueuePropertyAndMarket({
-  property_id = null,
-  market_id = null,
-  master_owner_id = null,
-  brain_item = null,
-} = {}) {
-  const queued_property_item = await safeGetItem(property_id);
-  let property_item =
-    queued_property_item ||
-    (await safeGetItem(getFirstAppReferenceId(brain_item, "properties", null)));
-
-  if (!property_item?.item_id && master_owner_id) {
-    try {
-      const response = await findPropertyItems({ "linked-master-owner": master_owner_id }, 1, 0);
-      property_item = response?.items?.[0] ?? response?.[0] ?? null;
-    } catch (_error) {
-      property_item = null;
-    }
-  }
-
-  const queued_market_item = await safeGetItem(market_id);
-  const derived_market_id =
-    queued_market_item?.item_id ??
-    getFirstAppReferenceId(property_item, "market-2", null) ??
-    getFirstAppReferenceId(property_item, "market", null) ??
-    null;
-
-  const market_item =
-    queued_market_item?.item_id && String(queued_market_item.item_id) === String(derived_market_id || "")
-      ? queued_market_item
-      : await safeGetItem(derived_market_id);
-
-  return {
-    property_item,
-    market_item,
-    property_id: property_item?.item_id ?? property_id ?? null,
-    market_id: market_item?.item_id ?? derived_market_id ?? market_id ?? null,
-  };
-}
-
-export function validateQueuedOutboundNumberItem(
-  outbound_number_item = null,
-  now = new Date()
-) {
-  const status = getCategoryValue(
-    outbound_number_item,
-    TEXTGRID_NUMBER_FIELDS.status,
-    null
+  await updateQueueRow(
+    queue_row_id,
+    {
+      queue_status: "sending",
+      retry_count: retry_count + 1,
+    },
+    deps
   );
-  const hard_pause = getCategoryValue(
+
+  return {
+    ok: true,
+    queue_row_id,
+    retry_count: retry_count + 1,
+  };
+}
+
+export async function failQueueItem(queue_row_or_id, error_or_options = {}, deps = {}) {
+  const provided_queue_row =
+    typeof queue_row_or_id === "object" && queue_row_or_id
+      ? queue_row_or_id
+      : { id: queue_row_or_id };
+  const queue_row_id = getQueueRowId(provided_queue_row);
+  const retry_count = asNonNegativeInteger(
+    provided_queue_row?.retry_count ?? error_or_options?.retry_count,
+    0
+  );
+  const failed_reason =
+    typeof error_or_options === "string"
+      ? error_or_options
+      : clean(error_or_options?.failed_reason || error_or_options?.message);
+
+  const failure_message = failed_reason || "queue_processing_failed";
+  const lock_token = clean(
+    deps.lock_token || provided_queue_row?.lock_token || error_or_options?.lock_token
+  );
+
+  if (queue_row_id && (isSupabaseQueueRow(provided_queue_row) || lock_token)) {
+    const queue_row =
+      isSupabaseQueueRow(provided_queue_row)
+        ? normalizeSendQueueRow(provided_queue_row)
+        : await loadQueueRowById(queue_row_id, deps);
+
+    if (queue_row) {
+      const failure_error =
+        error_or_options instanceof Error
+          ? error_or_options
+          : new Error(failure_message);
+
+      try {
+        const failed_row = lock_token
+          ? await finalizeSendQueueFailure(queue_row, lock_token, failure_error, {
+              ...deps,
+              now: deps.now || nowIso(),
+            })
+          : await updateQueueRow(
+              queue_row_id,
+              {
+                queue_status: "failed",
+                failed_reason: failure_message,
+                retry_count,
+                is_locked: false,
+                locked_at: null,
+                lock_token: null,
+                updated_at: deps.now || nowIso(),
+              },
+              deps
+            );
+
+        try {
+          await writeOutboundFailureMessageEvent(queue_row, failure_error, {
+            ...deps,
+            now: deps.now || nowIso(),
+            send_result:
+              typeof error_or_options === "object" ? error_or_options : null,
+          });
+        } catch (message_event_error) {
+          warn("queue.failure_message_event_write_failed", {
+            queue_row_id,
+            message: message_event_error?.message || "Unknown message event error",
+          });
+        }
+
+        return {
+          ok: false,
+          sent: false,
+          queue_status: failed_row?.queue_status || "failed",
+          failed_reason: failure_message,
+          queue_row_id,
+          queue_item_id: queue_row_id,
+        };
+      } catch (supabase_failure_error) {
+        warn("queue.supabase_fail_update_failed", {
+          queue_row_id,
+          message: supabase_failure_error?.message || "Unknown queue failure update error",
+        });
+      }
+    }
+  }
+
+  await updateQueueRow(
+    queue_row_id,
+    {
+      queue_status: "failed",
+      failed_reason: failure_message,
+      retry_count,
+    },
+    deps
+  );
+
+  return {
+    ok: false,
+    sent: false,
+    queue_status: "failed",
+    failed_reason: failure_message,
+    queue_row_id,
+    queue_item_id: queue_row_id,
+  };
+}
+
+export function validateQueuedOutboundNumberItem(outbound_number_item = null, now = new Date()) {
+  const status = getCategoryLike(outbound_number_item, TEXTGRID_NUMBER_FIELDS.status, null);
+  const hard_pause = getCategoryLike(
     outbound_number_item,
     TEXTGRID_NUMBER_FIELDS.hard_pause,
     null
   );
-  const pause_until = getDateValue(
+  const pause_until = getDateLike(
     outbound_number_item,
     TEXTGRID_NUMBER_FIELDS.pause_until,
     null
   );
   const normalized_from = normalizePhone(
-    getPhoneValue(outbound_number_item, "phone-number", "") ||
-      getTextValue(outbound_number_item, TEXTGRID_NUMBER_FIELDS.title, "")
+    getTextLike(outbound_number_item, "phone-number", "") ||
+      getTextLike(outbound_number_item, TEXTGRID_NUMBER_FIELDS.title, "")
   );
 
   if (!outbound_number_item?.item_id) {
@@ -1011,63 +559,31 @@ export function buildFailedOutboundMessageEventFields({
   next_expected_stage = null,
   selected_variant_group = null,
   selected_tone = null,
-  send_result,
-  retry_count,
-  max_retries,
-  client_reference_id,
+  send_result = {},
+  retry_count = 0,
+  max_retries = 3,
+  client_reference_id = null,
   prior_message_id = null,
   response_to_message_id = null,
-}) {
-  const ai_route = getCategoryValue(brain_item, "ai-route", null);
-  const stage_before = getCategoryValue(brain_item, "conversation-stage", null);
-  const missing_relation_warnings = [];
-
-  if (phone_item_id && !asArrayAppRef(phone_item_id)) {
-    missing_relation_warnings.push("phone_relation_invalid");
-  }
-  if (property_id && !asArrayAppRef(property_id)) {
-    missing_relation_warnings.push("property_relation_invalid");
-  }
-  if (template_id && !asArrayAppRef(template_id)) {
-    missing_relation_warnings.push("template_relation_invalid");
-  }
-  if (sms_agent_id && !asArrayAppRef(sms_agent_id)) {
-    missing_relation_warnings.push("sms_agent_relation_invalid");
-  }
-  if (conversation_item_id && !asArrayAppRef(conversation_item_id)) {
-    missing_relation_warnings.push("conversation_relation_invalid");
-  }
-
-  if (missing_relation_warnings.length) {
-    warn("events.failed_outbound_relation_payload_incomplete", {
-      queue_item_id,
-      master_owner_id,
-      prospect_id,
-      property_id,
-      market_id,
-      phone_item_id,
-      outbound_number_item_id,
-      sms_agent_id,
-      conversation_item_id,
-      template_id,
-      warnings: missing_relation_warnings,
-    });
-  }
+} = {}) {
+  const provider_message_id = getConfirmedProviderMessageSid(send_result);
+  const ai_route = getCategoryLike(brain_item, "ai-route", null);
+  const stage_before = getCategoryLike(brain_item, "conversation-stage", null);
 
   return buildBaseSellerMessageEventFields({
     message_event_key: buildFailedMessageEventKey({
       queue_item_id,
       client_reference_id,
-      provider_message_id: send_result.message_id,
+      provider_message_id,
     }),
-    provider_message_id: send_result.message_id || null,
-    timestamp: nowIso(),
+    provider_message_id,
+    timestamp: nowPodioDateTimeCentral(),
     direction: "Outbound",
     event_type: "Send Failure",
     message_body,
     delivery_status: "Failed",
-    provider_delivery_status: send_result.status || "failed",
-    raw_carrier_status: String(send_result.error_status || send_result.status || ""),
+    provider_delivery_status: send_result?.status || "failed",
+    raw_carrier_status: String(send_result?.error_status || send_result?.status || ""),
     message_variant,
     latency_ms,
     property_address,
@@ -1077,7 +593,8 @@ export function buildFailedOutboundMessageEventFields({
     trigger_name:
       queue_item_id ? buildQueueSendFailedTriggerName(queue_item_id) : "queue-send-failed",
     failure_bucket: mapTextgridFailureBucket(send_result) || "Other",
-    is_final_failure: retry_count + 1 >= max_retries,
+    is_final_failure:
+      asNonNegativeInteger(retry_count, 0) + 1 >= asNonNegativeInteger(max_retries, 3),
     prior_message_id,
     response_to_message_id,
     stage_before,
@@ -1096,11 +613,11 @@ export function buildFailedOutboundMessageEventFields({
     metadata: buildQueueMessageEventMetadata({
       queue_item_id,
       client_reference_id,
-      provider_message_id: send_result.message_id,
+      provider_message_id,
       message_event_key: buildFailedMessageEventKey({
         queue_item_id,
         client_reference_id,
-        provider_message_id: send_result.message_id,
+        provider_message_id,
       }),
       event_kind: "outbound_send_failed",
       message_variant,
@@ -1122,153 +639,116 @@ export function buildFailedOutboundMessageEventFields({
   });
 }
 
-export async function logFailedOutboundMessageEvent(payload = {}) {
-  const created = await createMessageEvent(buildFailedOutboundMessageEventFields(payload));
-
-  await linkMessageEventToBrain({
-    brain_item: payload.brain_item || null,
-    brain_id: payload.conversation_item_id || payload.brain_item?.item_id || null,
-    message_event_id: created?.item_id ?? null,
-  });
-
-  return created;
-}
-
-export async function failQueueItem(
-  queue_item_id,
+export async function finalizeSuccessfulQueueSend(
   {
-    queue_status = "Failed",
-    failed_reason = "Network Error",
-    retry_count = null,
-    delivery_confirmed = "❌ Failed",
-    _phase = "status_update",
-  } = {}
+    queue_row = null,
+    queue_item_id = null,
+    phone_item = null,
+    phone_item_id = null,
+    brain_id = null,
+    brain_item = null,
+    conversation_item_id = null,
+    master_owner_id = null,
+    prospect_id = null,
+    property_id = null,
+    market_id = null,
+    outbound_number_item_id = null,
+    sms_agent_id = null,
+    property_address = null,
+    template_id = null,
+    message_body = "",
+    message_variant = null,
+    latency_ms = null,
+    selected_use_case = null,
+    template_use_case = null,
+    next_expected_stage = null,
+    selected_variant_group = null,
+    selected_tone = null,
+    send_result = {},
+    current_total_messages_sent = 0,
+    client_reference_id = null,
+    now = nowIso(),
+    prior_message_id = null,
+    response_to_message_id = null,
+  } = {},
+  deps = {}
 ) {
-  const payload = {
-    [QUEUE_FIELDS.queue_status]: queue_status,
-    [QUEUE_FIELDS.failed_reason]: failed_reason,
-    [QUEUE_FIELDS.delivery_confirmed]: delivery_confirmed,
-  };
+  const resolved_queue_row_id = asPositiveInteger(
+    queue_item_id || getQueueRowId(queue_row),
+    null
+  );
+  const resolved_phone_item_id =
+    asPositiveInteger(phone_item_id, null) ||
+    getQueueRowRelationId(queue_row, ["phone_item_id", "phone_id"], null);
+  const resolved_brain_id =
+    asPositiveInteger(brain_id, null) ||
+    asPositiveInteger(conversation_item_id, null) ||
+    getQueueRowRelationId(queue_row, ["brain_id", "conversation_item_id"], null);
+  const resolved_master_owner_id =
+    asPositiveInteger(master_owner_id, null) ||
+    getQueueRowRelationId(queue_row, ["master_owner_id"], null);
+  const resolved_prospect_id =
+    asPositiveInteger(prospect_id, null) ||
+    getQueueRowRelationId(queue_row, ["prospect_id"], null);
+  const resolved_property_id =
+    asPositiveInteger(property_id, null) ||
+    getQueueRowRelationId(queue_row, ["property_id"], null);
+  const resolved_market_id =
+    asPositiveInteger(market_id, null) ||
+    getQueueRowRelationId(queue_row, ["market_id"], null);
+  const resolved_outbound_number_item_id =
+    asPositiveInteger(outbound_number_item_id, null) ||
+    getQueueRowRelationId(queue_row, [
+      "outbound_number_item_id",
+      "textgrid_number_item_id",
+      "from_number_item_id",
+    ]);
+  const resolved_template_id =
+    asPositiveInteger(template_id, null) ||
+    getQueueRowRelationId(queue_row, ["template_id", "selected_template_id"], null);
+  const resolved_client_reference_id =
+    clean(client_reference_id) ||
+    clean(
+      getQueueRowValue(queue_row, [
+        "client_reference_id",
+        "queue_id",
+        "queue_id_2",
+      ])
+    ) ||
+    (resolved_queue_row_id ? `queue-${resolved_queue_row_id}` : null);
+  const provider_message_sid = getConfirmedProviderMessageSid(send_result);
 
-  if (typeof retry_count === "number") {
-    payload[QUEUE_FIELDS.retry_count] = retry_count;
+  if (!provider_message_sid) {
+    throw new Error("SEND FAILED - NO SID");
   }
 
-  try {
-    await updateItem(queue_item_id, payload);
-  } catch (error) {
-    logRevisionLimitPhase(queue_item_id, "fail_queue_item", _phase, error);
-    throw error;
-  }
-}
-
-async function claimQueueItemForSending(
-  queue_item_id,
-  queue_item,
-  retry_count,
-  extra_fields = {}
-) {
-  const revision = extractItemRevision(queue_item);
-  const payload = {
-    ...extra_fields,
-    [QUEUE_FIELDS.queue_status]: "Sending",
-    [QUEUE_FIELDS.retry_count]: retry_count + 1,
-    [QUEUE_FIELDS.delivery_confirmed]: "⏳ Pending",
-  };
-
-  if (revision === null) {
-    try {
-      await updateItem(queue_item_id, payload);
-    } catch (error) {
-      logRevisionLimitPhase(queue_item_id, "claim_for_sending", "status_transition", error);
-      throw error;
-    }
-
-    return {
-      ok: true,
-      optimistic: false,
-      revision: null,
-    };
-  }
-
-  try {
-    await updateItem(queue_item_id, payload, revision);
-
-    return {
-      ok: true,
-      optimistic: true,
-      revision,
-    };
-  } catch (error) {
-    if (error instanceof PodioError && error.status === 409) {
-      return {
-        ok: false,
-        skipped: true,
-        reason: "queue_item_claim_conflict",
-      };
-    }
-
-    logRevisionLimitPhase(queue_item_id, "claim_for_sending", "optimistic_lock", error);
-    throw error;
-  }
-}
-
-export async function finalizeSuccessfulQueueSend({
-  queue_item_id,
-  phone_item,
-  phone_item_id,
-  brain_id = null,
-  brain_item = null,
-  conversation_item_id = null,
-  master_owner_id = null,
-  prospect_id = null,
-  property_id = null,
-  market_id = null,
-  outbound_number_item_id = null,
-  sms_agent_id = null,
-  property_address = null,
-  template_id = null,
-  message_body = "",
-  message_variant = null,
-  latency_ms = null,
-  selected_use_case = null,
-  template_use_case = null,
-  next_expected_stage = null,
-  selected_variant_group = null,
-  selected_tone = null,
-  send_result = {},
-  current_total_messages_sent = 0,
-  client_reference_id = null,
-  now = nowIso(),
-  prior_message_id = null,
-  response_to_message_id = null,
-} = {}, deps = {}) {
-  const update = deps.updateItem || updateItem;
-  const logOutbound = deps.logOutboundMessageEvent || logOutboundMessageEvent;
-  const updateBrain = deps.updateBrainAfterSend || updateBrainAfterSend;
-  const updateMasterOwner =
+  const queue_sent_update =
+    deps.updateItem ||
+    deps.updateQueueRow ||
+    (async (item_id, payload) => updateQueueRow(item_id, payload, deps));
+  const log_outbound_message_event =
+    deps.logOutboundMessageEvent || logOutboundMessageEvent;
+  const update_brain_after_send =
+    deps.updateBrainAfterSend || updateBrainAfterSend;
+  const update_master_owner_after_send =
     deps.updateMasterOwnerAfterSend || updateMasterOwnerAfterSend;
 
+  const sent_at_central = nowPodioDateTimeCentral(now);
   const bookkeeping_errors = [];
   let outbound_event = null;
 
-  // Sent At is written in America/Chicago so ops sees Central time in Podio.
-  // `now` (UTC ISO) is kept for master-owner bookkeeping; the queue field gets
-  // the Central-formatted string so Podio displays it without re-conversion.
-  const sent_at_central = nowPodioDateTimeCentral(now);
-
   info("queue.sent_at_timezone_conversion", {
-    queue_item_id,
+    queue_item_id: resolved_queue_row_id,
     sent_at_utc: now,
     sent_at_central,
     timezone: "America/Chicago",
   });
 
   try {
-    await update(queue_item_id, {
-      [QUEUE_FIELDS.queue_status]: "Sent",
-      [QUEUE_FIELDS.sent_at]: { start: sent_at_central },
-      [QUEUE_FIELDS.delivery_confirmed]: "⏳ Pending",
+    await queue_sent_update(resolved_queue_row_id, {
+      queue_status: "sent",
+      sent_at: now,
+      provider_message_id: provider_message_sid,
     });
   } catch (error) {
     bookkeeping_errors.push(
@@ -1277,32 +757,32 @@ export async function finalizeSuccessfulQueueSend({
   }
 
   try {
-    outbound_event = await logOutbound({
+    outbound_event = await log_outbound_message_event({
       brain_item,
-      conversation_item_id: conversation_item_id || brain_id,
-      master_owner_id,
-      prospect_id,
-      property_id,
-      market_id,
-      phone_item_id,
-      outbound_number_item_id,
+      conversation_item_id: resolved_brain_id,
+      master_owner_id: resolved_master_owner_id,
+      prospect_id: resolved_prospect_id,
+      property_id: resolved_property_id,
+      market_id: resolved_market_id,
+      phone_item_id: resolved_phone_item_id,
+      outbound_number_item_id: resolved_outbound_number_item_id,
       sms_agent_id,
       property_address,
       message_body,
-      provider_message_id: send_result.message_id,
-      queue_item_id,
-      client_reference_id,
-      template_id,
+      provider_message_id: provider_message_sid,
+      queue_item_id: resolved_queue_row_id,
+      client_reference_id: resolved_client_reference_id,
+      template_id: resolved_template_id,
       message_variant,
       latency_ms,
       send_result,
-      ...(selected_use_case ? { selected_use_case } : {}),
-      ...(template_use_case ? { template_use_case } : {}),
-      ...(next_expected_stage ? { next_expected_stage } : {}),
-      ...(selected_variant_group ? { selected_variant_group } : {}),
-      ...(selected_tone ? { selected_tone } : {}),
-      ...(prior_message_id ? { prior_message_id } : {}),
-      ...(response_to_message_id ? { response_to_message_id } : {}),
+      selected_use_case,
+      template_use_case,
+      next_expected_stage,
+      selected_variant_group,
+      selected_tone,
+      prior_message_id,
+      response_to_message_id,
       sent_at: sent_at_central,
     });
   } catch (error) {
@@ -1312,22 +792,16 @@ export async function finalizeSuccessfulQueueSend({
   }
 
   try {
-    await updateBrain({
-      brain_id,
-      phone_item_id,
+    await update_brain_after_send({
+      brain_id: resolved_brain_id,
+      phone_item_id: resolved_phone_item_id,
       message_body,
-      template_id,
+      template_id: resolved_template_id,
       current_total_messages_sent,
-      conversation_stage: deriveQueueCurrentStage({
-        conversation_stage: getCategoryValue(brain_item, "conversation-stage", null),
-        use_case: selected_use_case || template_use_case || null,
-      }),
-      current_follow_up_step: getCategoryValue(brain_item, "follow-up-step", null),
-      status_ai_managed: getCategoryValue(brain_item, "status-ai-managed", null),
       now,
-      master_owner_id,
-      prospect_id,
-      property_id,
+      master_owner_id: resolved_master_owner_id,
+      prospect_id: resolved_prospect_id,
+      property_id: resolved_property_id,
       sms_agent_id,
       message_event_id: outbound_event?.item_id || null,
     });
@@ -1338,9 +812,9 @@ export async function finalizeSuccessfulQueueSend({
   }
 
   try {
-    if (master_owner_id) {
-      await updateMasterOwner({
-        master_owner_id,
+    if (resolved_master_owner_id) {
+      await update_master_owner_after_send({
+        master_owner_id: resolved_master_owner_id,
         sent_at: now,
         selected_use_case,
       });
@@ -1353,648 +827,472 @@ export async function finalizeSuccessfulQueueSend({
 
   return {
     ok: bookkeeping_errors.length === 0,
-    sent: true,
     partial: bookkeeping_errors.length > 0,
-    queue_item_id,
-    provider_message_id: send_result.message_id,
-    to: send_result.to,
-    from: send_result.from,
-    brain_id,
+    sent: true,
+    queue_item_id: resolved_queue_row_id,
+    queue_row_id: resolved_queue_row_id,
+    queue_status: "sent",
+    provider_message_id: provider_message_sid,
+    message_id: provider_message_sid,
+    sid: provider_message_sid,
     bookkeeping_errors,
-    phone_item_id: phone_item?.item_id || phone_item_id || null,
+    outbound_event,
+    phone_item,
   };
 }
 
-export async function processSendQueueItem(queue_item_id) {
-  info("queue.process_started", { queue_item_id });
+async function processLegacyQueueItem(resolved_queue_row, deps = {}) {
+  const queue_row_id = getQueueRowId(resolved_queue_row);
+  const retry_count = asNonNegativeInteger(resolved_queue_row?.retry_count, 0);
+  const message_fields = pickMessageFields(resolved_queue_row);
+  const started_at = Date.now();
+  const send_textgrid_sms = deps.sendTextgridSMS || sendTextgridSMS;
 
-  let queue_item = await getItem(queue_item_id);
-  if (!queue_item) {
-    throw new Error(`Queue item not found: ${queue_item_id}`);
+  if (!queue_row_id) {
+    return {
+      ok: false,
+      sent: false,
+      reason: "missing_queue_row_id",
+    };
   }
 
-  const initial_phone_item_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.phone_number, null);
-  const initial_master_owner_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.master_owner, null);
-  const initial_prospect_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.prospects, null);
-  const has_persisted_message_text = Boolean(
-    clean(getTextValue(queue_item, QUEUE_FIELDS.message_text, ""))
-  );
-  let initial_phone_item = null;
-  let initial_brain_item = null;
+  try {
+    await markQueueRowSending(resolved_queue_row, deps);
 
-  if (!has_persisted_message_text) {
-    [initial_phone_item, initial_brain_item] = await Promise.all([
-      initial_phone_item_id ? safeGetItem(initial_phone_item_id) : Promise.resolve(null),
-      resolveBrainForQueue({
-        phone_item_id: initial_phone_item_id,
-        master_owner_id: initial_master_owner_id,
-        prospect_id: initial_prospect_id,
-      }),
-    ]);
-  }
-
-  const message_resolution = await resolveDeferredQueueMessage(queue_item, {
-    queue_item_id,
-    phone_item: initial_phone_item,
-    brain_item: initial_brain_item,
-  });
-
-  if (!message_resolution.ok) {
-    warn("queue.process_message_resolution_failed", {
-      queue_item_id,
-      reason: message_resolution.reason,
-      details: message_resolution.details || null,
+    console.log("ABOUT TO SEND MESSAGE");
+    console.log("SENDING SMS", {
+      to: message_fields.to,
+      from: message_fields.from,
     });
 
-    await failQueueItem(queue_item_id, {
-      queue_status: "Blocked",
-      failed_reason: "Network Error",
-      _phase: "message_resolution_failed",
+    const send_result = await send_textgrid_sms({
+      to: message_fields.to,
+      from: message_fields.from,
+      body: message_fields.body,
     });
 
-      return {
-        ok: false,
-        reason: message_resolution.reason,
-        details: message_resolution.details || null,
-        queue_status: "Blocked",
-        failed_reason: "Network Error",
-        claimed: false,
-      };
+    console.log("TEXTGRID RAW RESPONSE", send_result?.raw ?? null);
+    console.log("SEND RESULT", send_result);
+    console.log("MESSAGE SEND COMPLETE");
+
+    const provider_message_sid = getConfirmedProviderMessageSid(send_result);
+    if (!provider_message_sid) {
+      throw new Error("SEND FAILED - NO SID");
     }
 
-  if (message_resolution.queue_item?.item_id) {
-    queue_item = message_resolution.queue_item;
+    const finalized = await finalizeSuccessfulQueueSend(
+      {
+        queue_row: resolved_queue_row,
+        queue_item_id: queue_row_id,
+        phone_item_id: getQueueRowRelationId(resolved_queue_row, [
+          "phone_item_id",
+          "phone_id",
+        ]),
+        brain_id: getQueueRowRelationId(resolved_queue_row, [
+          "brain_id",
+          "conversation_item_id",
+        ]),
+        conversation_item_id: getQueueRowRelationId(resolved_queue_row, [
+          "conversation_item_id",
+          "brain_id",
+        ]),
+        master_owner_id: getQueueRowRelationId(resolved_queue_row, ["master_owner_id"]),
+        prospect_id: getQueueRowRelationId(resolved_queue_row, ["prospect_id"]),
+        property_id: getQueueRowRelationId(resolved_queue_row, ["property_id"]),
+        market_id: getQueueRowRelationId(resolved_queue_row, ["market_id"]),
+        outbound_number_item_id: getQueueRowRelationId(resolved_queue_row, [
+          "outbound_number_item_id",
+          "textgrid_number_item_id",
+          "from_number_item_id",
+        ]),
+        sms_agent_id: getQueueRowRelationId(resolved_queue_row, ["sms_agent_id"]),
+        property_address: clean(
+          getQueueRowValue(resolved_queue_row, ["property_address"])
+        ) || null,
+        template_id: getQueueRowRelationId(resolved_queue_row, [
+          "template_id",
+          "selected_template_id",
+        ]),
+        message_body: message_fields.body,
+        message_variant: getQueueRowValue(
+          resolved_queue_row,
+          ["message_variant"],
+          null
+        ),
+        latency_ms: Date.now() - started_at,
+        selected_use_case: clean(
+          getQueueRowValue(resolved_queue_row, ["selected_use_case"])
+        ) || null,
+        template_use_case: clean(
+          getQueueRowValue(resolved_queue_row, ["template_use_case"])
+        ) || null,
+        next_expected_stage: clean(
+          getQueueRowValue(resolved_queue_row, ["next_expected_stage"])
+        ) || null,
+        selected_variant_group: clean(
+          getQueueRowValue(resolved_queue_row, ["selected_variant_group"])
+        ) || null,
+        selected_tone: clean(
+          getQueueRowValue(resolved_queue_row, ["selected_tone"])
+        ) || null,
+        send_result,
+        current_total_messages_sent: asNonNegativeInteger(
+          getQueueRowValue(resolved_queue_row, [
+            "current_total_messages_sent",
+            "total_messages_sent",
+          ]),
+          0
+        ),
+        client_reference_id:
+          clean(
+            getQueueRowValue(resolved_queue_row, [
+              "client_reference_id",
+              "queue_id",
+              "queue_id_2",
+            ])
+          ) || `queue-${queue_row_id}`,
+        now: nowIso(),
+        prior_message_id: clean(
+          getQueueRowValue(resolved_queue_row, ["prior_message_id"])
+        ) || null,
+        response_to_message_id: clean(
+          getQueueRowValue(resolved_queue_row, ["response_to_message_id"])
+        ) || null,
+      },
+      deps
+    );
+
+    return {
+      ...finalized,
+      ok: finalized.ok !== false,
+      sent: true,
+      queue_status: "sent",
+      queue_row_id,
+      queue_item_id: queue_row_id,
+      provider_message_id: provider_message_sid,
+      message_id: provider_message_sid,
+      sid: provider_message_sid,
+    };
+  } catch (error) {
+    console.log("TEXTGRID RAW RESPONSE", error?.data || error?.raw_text || null);
+    console.log("SEND ERROR:", error?.message || "Unknown error");
+
+    try {
+      await failQueueItem(
+        {
+          ...resolved_queue_row,
+          retry_count: retry_count + 1,
+        },
+        {
+          failed_reason: error?.message || "queue_processing_failed",
+          retry_count: retry_count + 1,
+        },
+        deps
+      );
+    } catch (update_error) {
+      warn("queue.send.fail_update_failed", {
+        queue_row_id,
+        message: update_error?.message || "Unknown queue failure update error",
+      });
+    }
+
+    return toFailureResult(resolved_queue_row, error);
+  }
+}
+
+async function processSupabaseQueueItem(resolved_queue_row, deps = {}) {
+  const send_textgrid_sms = deps.sendTextgridSMS || sendTextgridSMS;
+  const started_at = Date.now();
+  const now = deps.now || nowIso();
+  let queue_row = normalizeSendQueueRow(resolved_queue_row);
+  const queue_row_id = getQueueRowId(queue_row);
+  let lock_token = clean(deps.claimedLockToken || queue_row?.lock_token) || null;
+
+  if (!queue_row_id) {
+    return {
+      ok: false,
+      sent: false,
+      reason: "missing_queue_row_id",
+    };
   }
 
-  const queue_validation = validateSendQueueItem(queue_item);
+  try {
+    if (!lock_token) {
+      const claim = await claimSendQueueRow(queue_row, {
+        ...deps,
+        now,
+      });
 
-  if (!queue_validation.ok) {
-    if (queue_validation.skipped) {
-      info("queue.process_skipped_terminal_status", {
-        queue_item_id,
-        queue_status: queue_validation.queue_status,
+      if (!claim?.claimed) {
+        return {
+          ok: true,
+          skipped: true,
+          reason: claim?.reason || "queue_item_claim_conflict",
+          queue_status: queue_row.queue_status,
+          queue_row_id,
+          queue_item_id: queue_row_id,
+        };
+      }
+
+      queue_row = normalizeSendQueueRow(claim.row || queue_row);
+      lock_token = claim.lock_token || lock_token;
+    }
+
+    const contact_window = evaluateContactWindow(queue_row, {
+      ...deps,
+      now,
+    });
+
+    console.log("CONTACT WINDOW CHECK", {
+      row_id: queue_row_id,
+      allowed: contact_window.allowed,
+      reason: contact_window.reason,
+      timezone: contact_window.timezone,
+      valid_window: contact_window.valid_window,
+    });
+
+    if (!contact_window.allowed) {
+      await releaseSkippedQueueRow(queue_row, lock_token, contact_window.reason, {
+        ...deps,
+        now,
       });
 
       return {
         ok: true,
         skipped: true,
-        reason: queue_validation.reason,
-        claimed: false,
+        reason: "outside_contact_window",
+        queue_status: "queued",
+        queue_row_id,
+        queue_item_id: queue_row_id,
       };
     }
 
-    if (queue_validation.reason === "missing_phone_item") {
-      await failQueueItem(queue_item_id, {
-        failed_reason: "Invalid Number",
-        retry_count: (queue_validation.retry_count ?? 0) + 1,
-      });
-    } else if (queue_validation.reason === "missing_textgrid_number") {
-      await failQueueItem(queue_item_id, {
-        failed_reason: "Network Error",
-        retry_count: (queue_validation.retry_count ?? 0) + 1,
-      });
-    } else if (queue_validation.reason === "empty_message_body") {
-      await failQueueItem(queue_item_id, {
-        failed_reason: "Network Error",
-        retry_count: (queue_validation.retry_count ?? 0) + 1,
-      });
-    } else if (queue_validation.reason === "junk_message_body") {
-      // One-word / too-short body — truncation artifact from multiline template stored
-      // in a single-line Podio field.  Block permanently; do NOT advance owner state.
-      warn("queue.process_blocked_junk_message_body", {
-        queue_item_id,
-        word_count: queue_validation.word_count,
-        message_body: queue_validation.message_body,
-      });
-      await failQueueItem(queue_item_id, {
-        queue_status: "Blocked",
-        failed_reason: "Content Filter",
-      });
-    } else if (queue_validation.reason === "max_retries_exceeded") {
-      await failQueueItem(queue_item_id, {
-        failed_reason: "Network Error",
-      });
-    } else if (queue_validation.reason === "invalid_touch_one_use_case") {
-      // FIX 10: Touch 1 rows with a wrong use_case are permanently blocked.
-      warn("queue.process_blocked_invalid_touch_one_use_case", {
-        queue_item_id,
-        use_case_template: queue_validation.use_case_template,
-        touch_number: queue_validation.touch_number,
-      });
-      await failQueueItem(queue_item_id, {
-        queue_status: "Blocked",
-        failed_reason: "Content Filter",
-      });
-    } else if (queue_validation.reason === "unattached_template") {
-      // Queue row has no template relation — cannot be sent.
-      // This should not happen for new rows (prevented by feeder guard),
-      // but may exist for legacy rows created during fallback mode.
-      warn("queue.process_blocked_unattached_template", {
-        queue_item_id,
-        reason: "queue_row_missing_template_relation",
-      });
-      await failQueueItem(queue_item_id, {
-        queue_status: "Blocked",
-        failed_reason: "Content Filter",
-      });
+    const number_selection = await selectAvailableTextgridNumber(queue_row, deps);
+    if (!number_selection?.ok) {
+      throw new Error(number_selection?.reason || "missing_from_phone_number");
     }
 
-    return {
-      ok: false,
-      reason: queue_validation.reason,
-      queue_status:
-        queue_validation.reason === "junk_message_body" || queue_validation.reason === "invalid_touch_one_use_case" || queue_validation.reason === "unattached_template"
-          ? "Blocked"
-          : "Failed",
-      failed_reason:
-        queue_validation.reason === "missing_phone_item"
-          ? "Invalid Number"
-          : queue_validation.reason === "junk_message_body" || queue_validation.reason === "invalid_touch_one_use_case" || queue_validation.reason === "unattached_template"
-            ? "Content Filter"
-            : "Network Error",
-      claimed: false,
+    if (
+      clean(number_selection.from_phone_number) &&
+      clean(number_selection.from_phone_number) !== clean(queue_row.from_phone_number)
+    ) {
+      queue_row = normalizeSendQueueRow(
+        await reserveFromPhoneNumber(queue_row, lock_token, number_selection, {
+          ...deps,
+          now,
+        })
+      );
+    }
+
+    const message_fields = {
+      to: normalizePhone(queue_row.to_phone_number),
+      from: normalizePhone(
+        queue_row.from_phone_number || number_selection.from_phone_number
+      ),
+      body: clean(queue_row.message_body || queue_row.message_text),
     };
-  }
 
-  const phone_item_id = queue_validation.phone_item_id;
-  const outbound_number_item_id = queue_validation.textgrid_number_item_id;
-  const message_body = queue_validation.message_text;
-  const retry_count = queue_validation.retry_count;
-  const max_retries = queue_validation.max_retries;
+    if (!message_fields.to) throw new Error("missing_to_phone_number");
+    if (!message_fields.from) throw new Error("missing_from_phone_number");
+    if (!message_fields.body) throw new Error("missing_message_body");
 
-  const template_relation_id =
-    message_resolution.template_relation_id ||
-    getFirstAppReferenceId(queue_item, QUEUE_FIELDS.template, null);
-  const selected_template_id =
-    message_resolution.selected_template_id ||
-    message_resolution.template_id ||
-    template_relation_id ||
-    null;
-  const selected_template_source = message_resolution.selected_template_source || null;
-  const selected_template_resolution_source =
-    message_resolution.selected_template_resolution_source || null;
-  const selected_template_fallback_reason =
-    message_resolution.selected_template_fallback_reason || null;
-  const selected_template_title = message_resolution.selected_template_title || null;
-  const master_owner_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.master_owner, null);
-  const prospect_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.prospects, null);
-  const property_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.properties, null);
-  const market_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.market, null);
-  const sms_agent_id = getFirstAppReferenceId(queue_item, QUEUE_FIELDS.sms_agent, null);
-  const property_address = getTextValue(queue_item, QUEUE_FIELDS.property_address, "") || "";
-  const message_variant = getTouchNumber(queue_item);
-  const canonical_flow =
-    message_resolution.canonical_flow ||
-    (await resolveCanonicalSellerFlowForQueue({
-      template_id: template_relation_id,
-      template_item: message_resolution.template_item || null,
-      message_body,
-    }));
-
-  const [phone_item, outbound_number_item] = await Promise.all([
-    initial_phone_item && String(initial_phone_item?.item_id || "") === String(phone_item_id)
-      ? Promise.resolve(initial_phone_item)
-      : safeGetItem(phone_item_id),
-    safeGetItem(outbound_number_item_id),
-  ]);
-
-  const phone_validation = validateActivePhone(phone_item);
-
-  if (!phone_validation.ok) {
-    warn("queue.process_blocked_phone_not_active", {
-      queue_item_id,
-      phone_item_id,
-      activity_status: phone_validation.activity_status,
-      reason: phone_validation.reason,
+    console.log("ABOUT TO SEND MESSAGE");
+    console.log("SENDING SMS", {
+      to: message_fields.to,
+      from: message_fields.from,
     });
 
-    await failQueueItem(queue_item_id, {
-      queue_status: "Blocked",
-      failed_reason: "Invalid Number",
-      retry_count: retry_count + 1,
+    const send_result = await send_textgrid_sms({
+      to: message_fields.to,
+      from: message_fields.from,
+      body: message_fields.body,
     });
 
-    return {
-      ok: false,
-      reason: phone_validation.reason,
-      queue_status: "Blocked",
-      failed_reason: "Invalid Number",
-      claimed: false,
-    };
-  }
+    console.log("TEXTGRID RAW RESPONSE", send_result?.raw ?? null);
+    console.log("SEND RESULT", send_result);
+    console.log("MESSAGE SEND COMPLETE");
 
-  const to_number =
-    getTextValue(phone_item, "canonical-e164", "") ||
-    normalizePhone(getTextValue(phone_item, "phone-hidden", ""));
-  const outbound_number_validation = validateQueuedOutboundNumberItem(
-    outbound_number_item
-  );
-  const from_number = outbound_number_validation.normalized_from || "";
-  const client_reference_id = buildQueueClientReferenceId(queue_item_id);
+    const provider_message_sid = getConfirmedProviderMessageSid(send_result);
+    if (!provider_message_sid) {
+      throw new Error("SEND FAILED - NO SID");
+    }
 
-  if (!to_number || !outbound_number_validation.ok) {
-    const preflight_reason = !to_number
-      ? "destination_number_invalid"
-      : outbound_number_validation.reason;
-    const preflight_message = !to_number
-      ? `Invalid destination number for phone item ${phone_item_id}`
-      : `Invalid sending number for TextGrid item ${outbound_number_item_id}: ${outbound_number_validation.reason}`;
-
-    await failQueueItem(queue_item_id, {
-      queue_status: "Blocked",
-      failed_reason: "Invalid Number",
-      retry_count: retry_count + 1,
+    queue_row = normalizeSendQueueRow({
+      ...queue_row,
+      from_phone_number: message_fields.from,
+      textgrid_number_id:
+        queue_row.textgrid_number_id || number_selection?.selected?.id || null,
+      character_count: message_fields.body.length,
+      message_body: message_fields.body,
+      message_text: message_fields.body,
     });
+
+    const finalized_row = await finalizeSendQueueSuccess(
+      queue_row,
+      lock_token,
+      send_result,
+      {
+        ...deps,
+        now,
+      }
+    );
+
+    const bookkeeping_errors = [];
+    let outbound_event = null;
 
     try {
-      await logFailedOutboundMessageEvent({
-        brain_item: null,
-        conversation_item_id: null,
-        queue_item_id,
-        master_owner_id,
-        prospect_id,
-        property_id,
-        market_id,
-        phone_item_id,
-        outbound_number_item_id,
-        sms_agent_id,
-        template_id: template_relation_id,
-        property_address,
-        message_body,
-        message_variant,
-        latency_ms: 0,
-        selected_use_case: canonical_flow?.selected_use_case || null,
-        template_use_case: canonical_flow?.template_use_case || null,
-        next_expected_stage: canonical_flow?.next_expected_stage || null,
-        selected_variant_group: canonical_flow?.selected_variant_group || null,
-        selected_tone: canonical_flow?.selected_tone || null,
-        send_result: {
-          ok: false,
-          provider: "textgrid",
-          message_id: null,
-          status: "failed",
-          error_status: "preflight_invalid_number",
-          error_message: preflight_message,
-          to: to_number || null,
-          from: from_number || null,
-          endpoint: getTextgridSendEndpoint(),
-        },
-        retry_count,
-        max_retries,
-        client_reference_id,
+      outbound_event = await writeOutboundSuccessMessageEvent(
+        finalized_row,
+        send_result,
+        {
+          ...deps,
+          now,
+          latency_ms: Date.now() - started_at,
+        }
+      );
+      console.log("MESSAGE EVENT WRITTEN", {
+        type: "success",
+        row_id: queue_row_id,
+        provider_message_sid,
       });
-    } catch (error) {
-      warn("queue.process_preflight_failed_event_log_failed", {
-        queue_item_id,
-        reason: preflight_reason,
-        message: error?.message || "unknown_error",
+    } catch (message_event_error) {
+      bookkeeping_errors.push(
+        `message_event_write_failed:${message_event_error?.message || "unknown_error"}`
+      );
+      warn("queue.success_message_event_write_failed", {
+        queue_row_id,
+        message: message_event_error?.message || "Unknown message event error",
       });
     }
 
-    return {
-      ok: false,
-      reason: preflight_reason,
-      queue_status: "Blocked",
-      failed_reason: "Invalid Number",
-      claimed: false,
-    };
-  }
-
-  const brain_item = initial_brain_item
-    ? initial_brain_item
-    : await resolveBrainForQueue({ phone_item_id, master_owner_id, prospect_id });
-  const brain_id = brain_item?.item_id ?? null;
-
-  const suppression = shouldSuppressOutreach({
-    phone_item,
-    brain_item,
-  });
-
-  if (suppression.suppress) {
-    warn("queue.process_suppressed", {
-      queue_item_id,
-      phone_item_id,
-      reason: suppression.reason,
-      details: suppression.details,
-    });
-
-    await failQueueItem(queue_item_id, {
-      queue_status: "Blocked",
-      failed_reason:
-        suppression.reason === "phone_post_contact_suppression" ||
-        suppression.reason === "classification_stop_texting"
-          ? "Opt-Out"
-          : "Network Error",
-    });
-
-    return {
-      ok: false,
-      suppressed: true,
-      reason: suppression.reason,
-      details: suppression.details,
-      queue_status: "Blocked",
-      failed_reason:
-        suppression.reason === "phone_post_contact_suppression" ||
-        suppression.reason === "classification_stop_texting"
-          ? "Opt-Out"
-          : "Network Error",
-      claimed: false,
-    };
-  }
-
-  // ── Pre-send stale-state guard ───────────────────────────────────────────
-  // Before claiming and sending, reload recent conversation events to catch
-  // negative replies that arrived after this queue item was created but before
-  // processSendQueue ran.  This is the second line of defence: the first is
-  // cancelPendingQueueItemsForOwner called synchronously from the inbound
-  // webhook handler, which cancels items to "Blocked" immediately.  The guard
-  // here catches the race where the inbound arrives after the item is fetched
-  // for processing but before it is claimed.
-  const queue_item_scheduled_ts =
-    toTimestamp(getDateValue(queue_item, QUEUE_FIELDS.scheduled_for_utc, null)) ||
-    toTimestamp(getDateValue(queue_item, QUEUE_FIELDS.scheduled_for_local, null)) ||
-    null;
-
-  let recent_events_result = null;
-  if (master_owner_id || phone_item_id) {
     try {
-      recent_events_result = await loadRecentEvents({
-        master_owner_id,
-        phone_item_id,
-        limit: 20,
+      if (number_selection?.selected?.id) {
+        await incrementTextgridNumberUsage(number_selection, {
+          ...deps,
+          now,
+        });
+      }
+    } catch (number_usage_error) {
+      bookkeeping_errors.push(
+        `textgrid_number_usage_update_failed:${number_usage_error?.message || "unknown_error"}`
+      );
+      warn("queue.textgrid_number_usage_update_failed", {
+        queue_row_id,
+        textgrid_number_id: number_selection?.selected?.id || null,
+        message: number_usage_error?.message || "Unknown number usage update error",
       });
-    } catch (_err) {
-      // Non-fatal: if recent events cannot be loaded, proceed with send.
     }
-  }
 
-  if (recent_events_result?.events?.length) {
-    const negative_inbound = recent_events_result.events.find((event) => {
-      if (lower(event.direction || "") !== "inbound") return false;
-      const event_ts = toTimestamp(event.timestamp);
-      if (!event_ts) return false;
-      // Only block if the inbound arrived after this item was scheduled
-      // (i.e. the seller replied AFTER we queued this touch).
-      if (queue_item_scheduled_ts && event_ts <= queue_item_scheduled_ts) return false;
-      return isNegativeReply(event.message || "");
+    console.log("SEND SUCCESS", {
+      row_id: queue_row_id,
+      provider_message_sid,
     });
 
-    if (negative_inbound) {
-      warn("queue.process_aborted_newer_negative_inbound", {
-        queue_item_id,
-        phone_item_id,
-        master_owner_id,
-        inbound_event_id: negative_inbound.item_id,
-        inbound_timestamp: negative_inbound.timestamp,
-        inbound_message: negative_inbound.message,
-        queue_item_scheduled_ts,
-      });
+    return {
+      ok: bookkeeping_errors.length === 0,
+      partial: bookkeeping_errors.length > 0,
+      sent: true,
+      queue_status: "sent",
+      queue_row_id,
+      queue_item_id: queue_row_id,
+      provider_message_id: provider_message_sid,
+      message_id: provider_message_sid,
+      sid: provider_message_sid,
+      bookkeeping_errors,
+      outbound_event,
+    };
+  } catch (error) {
+    console.log("TEXTGRID RAW RESPONSE", error?.data || error?.raw_text || null);
+    console.log("SEND ERROR:", error?.message || "Unknown error");
 
-      await failQueueItem(queue_item_id, {
-        queue_status: "Blocked",
-        failed_reason: "Opt-Out",
-        _phase: "pre_send_negative_inbound_guard",
-      });
+    try {
+      const failed_row = lock_token
+        ? await finalizeSendQueueFailure(queue_row, lock_token, error, {
+            ...deps,
+            now,
+          })
+        : null;
+
+      try {
+        await writeOutboundFailureMessageEvent(queue_row, error, {
+          ...deps,
+          now,
+          send_result: error?.data
+            ? {
+                ok: false,
+                error_message: error?.message,
+                error_status: error?.status || null,
+                raw: error?.data,
+              }
+            : null,
+        });
+        console.log("MESSAGE EVENT WRITTEN", {
+          type: "failure",
+          row_id: queue_row_id,
+        });
+      } catch (message_event_error) {
+        warn("queue.failure_message_event_write_failed", {
+          queue_row_id,
+          message: message_event_error?.message || "Unknown message event error",
+        });
+      }
 
       return {
-        ok: false,
-        reason: "newer_inbound_negative_reply",
-        queue_status: "Blocked",
-        failed_reason: "Opt-Out",
-        claimed: false,
+        ...toFailureResult(queue_row, error),
+        queue_status: failed_row?.queue_status || "failed",
       };
+    } catch (update_error) {
+      warn("queue.send.fail_update_failed", {
+        queue_row_id,
+        message: update_error?.message || "Unknown queue failure update error",
+      });
+      return toFailureResult(queue_row, error);
     }
   }
+}
 
-  const latest_outbound_event =
-    recent_events_result?.events?.find(
-      (event) => lower(event.direction || "") === "outbound"
-    ) || null;
-  const prior_message_id = clean(latest_outbound_event?.message_id) || null;
-  const response_to_message_id = prior_message_id;
+export async function processSendQueueItem(queue_row, deps = {}) {
+  const resolved_queue_row =
+    queue_row && typeof queue_row === "object" && !Array.isArray(queue_row)
+      ? queue_row
+      : await loadQueueRowById(queue_row, deps);
 
-  const { property_id: resolved_property_id, market_id: resolved_market_id } =
-    await resolveQueuePropertyAndMarket({
-      property_id,
-      market_id,
-      master_owner_id,
-      brain_item,
-    });
-
-  info("queue.process_send_preflight", {
-    queue_item_id,
-    phone_item_id,
-    outbound_number_item_id,
-    property_id: resolved_property_id,
-    template_id: template_relation_id,
-    selected_template_id,
-    selected_template_source,
-    selected_template_resolution_source,
-    selected_template_fallback_reason,
-    selected_template_title,
-    normalized_to: clean(to_number) || null,
-    normalized_from: clean(from_number) || null,
-    send_endpoint: getTextgridSendEndpoint(),
-    outbound_number_found: Boolean(outbound_number_item?.item_id),
-    outbound_number_valid: outbound_number_validation.ok,
-    outbound_number_status: outbound_number_validation.status || null,
-    outbound_number_hard_pause: outbound_number_validation.hard_pause || null,
-    outbound_number_pause_until: outbound_number_validation.pause_until || null,
-  });
-
-  const queue_context_updates = {
-    ...(!property_id && resolved_property_id
-      ? { [QUEUE_FIELDS.properties]: [resolved_property_id] }
-      : {}),
-    ...(!market_id && resolved_market_id
-      ? { [QUEUE_FIELDS.market]: [resolved_market_id] }
-      : {}),
-  };
-
-  const claim = await claimQueueItemForSending(
-    queue_item_id,
-    queue_item,
-    retry_count,
-    queue_context_updates
-  );
-
-  if (!claim.ok) {
-    info("queue.process_skipped_claim_conflict", {
-      queue_item_id,
-      reason: claim.reason,
-    });
-
-    return {
-      ok: true,
-      skipped: true,
-      reason: claim.reason,
-      claim_conflict: true,
-      claimed: false,
-    };
-  }
-
-  const send_started_at = Date.now();
-  const send_result = await sendTextgridSMS({
-    to: to_number,
-    from: from_number,
-    body: message_body,
-    message_type: "sms",
-    client_reference_id,
-  });
-  const latency_ms = Date.now() - send_started_at;
-
-  if (!send_result.ok) {
-    const failed_reason = mapFailureReasonToQueueCategory(send_result);
-    const bookkeeping_errors = [];
-
-    warn("queue.process_send_failed", {
-      queue_item_id,
-      phone_item_id,
-      outbound_number_item_id,
-      error_status: send_result.error_status,
-      error_message: send_result.error_message,
-      failed_reason,
-      normalized_to: send_result.to || to_number || null,
-      normalized_from: send_result.from || from_number || null,
-      send_endpoint: send_result.endpoint || getTextgridSendEndpoint(),
-      outbound_number_valid: outbound_number_validation.ok,
-      outbound_number_status: outbound_number_validation.status || null,
-    });
-
-    try {
-      await failQueueItem(queue_item_id, {
-        failed_reason,
-      });
-    } catch (error) {
-      bookkeeping_errors.push(
-        `queue_fail_update_failed:${error?.message || "unknown_error"}`
-      );
-    }
-
-    try {
-      await logFailedOutboundMessageEvent({
-        brain_item,
-        conversation_item_id: brain_id,
-        queue_item_id,
-        master_owner_id,
-        prospect_id,
-        property_id: resolved_property_id,
-        market_id: resolved_market_id,
-        phone_item_id,
-        outbound_number_item_id,
-        sms_agent_id,
-        template_id: template_relation_id,
-        property_address,
-        message_body,
-        message_variant,
-        latency_ms,
-        selected_use_case: canonical_flow?.selected_use_case || null,
-        template_use_case: canonical_flow?.template_use_case || null,
-        next_expected_stage: canonical_flow?.next_expected_stage || null,
-        selected_variant_group: canonical_flow?.selected_variant_group || null,
-        selected_tone: canonical_flow?.selected_tone || null,
-        send_result,
-        retry_count,
-        max_retries,
-        client_reference_id,
-        prior_message_id,
-        response_to_message_id,
-      });
-    } catch (error) {
-      bookkeeping_errors.push(
-        `failed_event_log_failed:${error?.message || "unknown_error"}`
-      );
-    }
-
+  if (!resolved_queue_row) {
     return {
       ok: false,
       sent: false,
-      reason: send_result.error_message || "textgrid_send_failed",
-      queue_status: "Failed",
-      failed_reason,
-      bookkeeping_errors,
-      claimed: true,
+      reason: "missing_queue_row",
     };
   }
 
-  const current_total_messages_sent = Number(
-    getNumberValue(phone_item, "total-messages-sent", 0) || 0
-  );
+  if (isSupabaseQueueRow(resolved_queue_row)) {
+    return processSupabaseQueueItem(resolved_queue_row, deps);
+  }
 
-  const bookkeeping_result = await finalizeSuccessfulQueueSend({
-    queue_item_id,
-    phone_item,
-    phone_item_id,
-    brain_id,
-    brain_item,
-    conversation_item_id: brain_id,
-    master_owner_id,
-    prospect_id,
-    property_id: resolved_property_id,
-    market_id: resolved_market_id,
-    outbound_number_item_id,
-    sms_agent_id,
-    property_address,
-    template_id: template_relation_id,
-    message_body,
-    message_variant,
-    latency_ms,
-    selected_use_case: canonical_flow?.selected_use_case || null,
-    template_use_case: canonical_flow?.template_use_case || null,
-    next_expected_stage: canonical_flow?.next_expected_stage || null,
-    selected_variant_group: canonical_flow?.selected_variant_group || null,
-    selected_tone: canonical_flow?.selected_tone || null,
-    send_result,
-    current_total_messages_sent,
-    client_reference_id,
-    prior_message_id,
-    response_to_message_id,
-  });
-
-  info("queue.process_completed", {
-    queue_item_id,
-    phone_item_id,
-    outbound_number_item_id,
-    template_id: template_relation_id,
-    selected_template_id,
-    selected_template_source,
-    selected_template_resolution_source,
-    selected_template_fallback_reason,
-    selected_template_title,
-    provider_message_id: send_result.message_id,
-    brain_id,
-    optimistic_claim: claim.optimistic,
-    bookkeeping_error_count: bookkeeping_result.bookkeeping_errors.length,
-  });
-
-  return {
-    ...bookkeeping_result,
-    queue_status: bookkeeping_result?.sent ? "Sent" : null,
-    template_relation_id,
-    selected_template_id,
-    selected_template_source,
-    selected_template_resolution_source,
-    selected_template_fallback_reason,
-    selected_template_title,
-    template_attached: message_resolution.template_attached ?? false,
-    claimed: true,
-  };
+  return processLegacyQueueItem(resolved_queue_row, deps);
 }
 
-export async function processSendQueue(input = {}) {
-  const queue_item_id =
-    typeof input === "number"
-      ? input
-      : input?.queue_item_id ?? null;
+export async function processSendQueue(input = {}, deps = {}) {
+  const queue_row =
+    input?.queue_row ||
+    input?.row ||
+    (input && typeof input === "object" && input.id ? input : null);
 
+  if (queue_row) {
+    return processSendQueueItem(queue_row, deps);
+  }
+
+  const queue_item_id = asPositiveInteger(input?.queue_item_id || input?.id, null);
   if (!queue_item_id) {
     return {
       ok: false,
-      reason: "missing_queue_item_id",
+      sent: false,
+      reason: "missing_queue_row",
     };
   }
 
-  return processSendQueueItem(queue_item_id);
+  const loaded = await loadQueueRowById(queue_item_id, deps);
+  return processSendQueueItem(loaded, deps);
 }
 
 export default processSendQueueItem;

--- a/src/lib/domain/queue/queue-run-request.js
+++ b/src/lib/domain/queue/queue-run-request.js
@@ -1,28 +1,18 @@
-import {
-  capQueueBatch,
-  getRolloutControls,
-  resolveMutationDryRun,
-  resolveScopedId,
-} from "@/lib/config/rollout-controls.js";
-import {
-  buildPodioCooldownSkipResult,
-  isPodioRateLimitError,
-  serializePodioError,
-} from "@/lib/providers/podio.js";
+function clean(value) {
+  return String(value ?? "").trim();
+}
 
 function asBoolean(value, fallback = false) {
   if (typeof value === "boolean") return value;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (["true", "1", "yes"].includes(normalized)) return true;
-    if (["false", "0", "no"].includes(normalized)) return false;
-  }
+  const normalized = clean(value).toLowerCase();
+  if (["true", "1", "yes"].includes(normalized)) return true;
+  if (["false", "0", "no"].includes(normalized)) return false;
   return fallback;
 }
 
 function asNumber(value, fallback = null) {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }
 
 export function statusForResult(result) {
@@ -30,6 +20,8 @@ export function statusForResult(result) {
 }
 
 export async function handleQueueRunRequest(request, method, deps = {}) {
+  console.log("QUEUE EXECUTION STARTED");
+
   const require_cron_auth =
     deps.requireCronAuth ||
     (await import("@/lib/security/cron-auth.js")).requireCronAuth;
@@ -37,7 +29,7 @@ export async function handleQueueRunRequest(request, method, deps = {}) {
     deps.runSendQueue ||
     (await import("@/lib/domain/queue/run-send-queue.js")).runSendQueue;
   const build_podio_cooldown_skip_result =
-    deps.buildPodioCooldownSkipResult || buildPodioCooldownSkipResult;
+    deps.buildPodioCooldownSkipResult || null;
   const route_logger = deps.logger;
   const json_response =
     deps.jsonResponse ||
@@ -52,65 +44,45 @@ export async function handleQueueRunRequest(request, method, deps = {}) {
     const auth = require_cron_auth(request, route_logger);
     if (!auth.authorized) return auth.response;
 
-    const { searchParams } = new URL(request.url);
     const body =
       method === "POST"
         ? await request.json().catch(() => ({}))
-        : null;
+        : {};
+    const search_params = new URL(request.url).searchParams;
 
-    const rollout = getRolloutControls();
-    const master_owner_scope = resolveScopedId({
-      requested_id: asNumber(
-        method === "POST" ? body?.master_owner_id : searchParams.get("master_owner_id"),
-        null
-      ),
-      safe_id: rollout.single_master_owner_id,
-      resource: "master_owner",
-    });
-    if (!master_owner_scope.ok) {
-      return json_response(
-        {
-          ok: false,
-          error: master_owner_scope.reason,
-        },
-        { status: 400 }
-      );
-    }
-
-    const limit = capQueueBatch(
-      asNumber(method === "POST" ? body?.limit : searchParams.get("limit"), 50),
-      50
+    const limit = Math.max(
+      1,
+      Math.min(
+        50,
+        asNumber(method === "POST" ? body?.limit : search_params.get("limit"), 50)
+      )
     );
-    const dry_run_resolution = resolveMutationDryRun({
-      requested_dry_run: asBoolean(
-        method === "POST" ? body?.dry_run : searchParams.get("dry_run"),
-        false
-      ),
-    });
+    const dry_run = asBoolean(
+      method === "POST" ? body?.dry_run : search_params.get("dry_run"),
+      false
+    );
 
     route_logger?.info?.("queue_run.requested", {
       method,
       limit,
-      dry_run: dry_run_resolution.effective_dry_run,
-      master_owner_id: master_owner_scope.effective_id,
+      dry_run,
       authenticated: auth.auth.authenticated,
       is_vercel_cron: auth.auth.is_vercel_cron,
     });
 
     route_logger?.info?.("queue_run.before_run_send_queue", {
       limit,
-      dry_run: dry_run_resolution.effective_dry_run,
-      dry_run_reason: dry_run_resolution.reason,
-      rollout_mode: dry_run_resolution.mode,
-      forced_dry_run: dry_run_resolution.forced,
-      master_owner_id: master_owner_scope.effective_id,
-      scope_reason: master_owner_scope.reason,
+      dry_run,
+      dry_run_reason: dry_run ? "requested" : "disabled",
+      rollout_mode: process.env.ROLLOUT_MODE || null,
+      forced_dry_run: false,
+      master_owner_id: null,
+      scope_reason: "supabase_queue_runner",
     });
 
     const result = await run_send_queue({
       limit,
-      dry_run: dry_run_resolution.effective_dry_run,
-      master_owner_id: master_owner_scope.effective_id,
+      dry_run,
     });
 
     if (result?.skipped) {
@@ -160,35 +132,42 @@ export async function handleQueueRunRequest(request, method, deps = {}) {
       { status: statusForResult(result) }
     );
   } catch (error) {
-    const diagnostics = serializePodioError(error);
+    const diagnostics = {
+      name: error?.name || "Error",
+      message: error?.message || "queue_run_failed",
+      status: Number(error?.status || 0) || null,
+      path: clean(error?.path) || null,
+      method: clean(error?.method) || null,
+      operation: clean(error?.operation) || null,
+      retry_after_seconds:
+        error?.retry_after_seconds === undefined ||
+        error?.retry_after_seconds === null
+          ? null
+          : Number(error.retry_after_seconds),
+      rate_limit_remaining:
+        error?.rate_limit_remaining === undefined ||
+        error?.rate_limit_remaining === null
+          ? null
+          : Number(error.rate_limit_remaining),
+      stack: error?.stack || null,
+    };
 
     route_logger?.error?.("queue_run.failed", {
       method,
       error: diagnostics,
     });
 
-    if (isPodioRateLimitError(error)) {
+    if (
+      build_podio_cooldown_skip_result &&
+      diagnostics.name === "PodioError" &&
+      diagnostics.status === 420
+    ) {
       const result = await build_podio_cooldown_skip_result({
-        dry_run: false,
-        total_rows_loaded: 0,
-        queued_rows_loaded: 0,
-        due_rows: 0,
-        future_rows: 0,
-        outside_window_rows: 0,
-        attempted_count: 0,
-        claimed_count: 0,
-        started_count: 0,
+        results: [],
         processed_count: 0,
         sent_count: 0,
         failed_count: 0,
-        blocked_count: 0,
         skipped_count: 0,
-        duplicate_locked_count: 0,
-        first_failure_queue_item_id: null,
-        first_failure_reason: null,
-        batch_duration_ms: 0,
-        results: [],
-        run_started_at: new Date().toISOString(),
       });
 
       return json_response(
@@ -211,3 +190,5 @@ export async function handleQueueRunRequest(request, method, deps = {}) {
     );
   }
 }
+
+export default handleQueueRunRequest;

--- a/src/lib/domain/queue/run-send-queue.js
+++ b/src/lib/domain/queue/run-send-queue.js
@@ -8,6 +8,7 @@ import { hasSupabaseConfig } from "@/lib/supabase/client.js";
 import {
   claimSendQueueRow,
   loadRunnableSendQueueRows,
+  normalizeQueueRowId,
 } from "@/lib/supabase/sms-engine.js";
 
 const DEFAULT_BATCH_SIZE = 50;
@@ -82,7 +83,10 @@ function toTimestamp(value) {
 }
 
 function getQueueRowId(row = null) {
-  return asPositiveInteger(row?.id ?? row?.queue_item_id ?? row?.item_id, null);
+  return normalizeQueueRowId(
+    row?.queue_row_id ?? row?.id ?? row?.queue_item_id ?? row?.item_id,
+    null
+  );
 }
 
 function getQueueStatus(row = null) {
@@ -266,6 +270,7 @@ function classifyRunResult(result = {}) {
 function buildSkippedSummary(queue_item_id, reason) {
   return {
     queue_item_id,
+    queue_row_id: queue_item_id,
     reason,
   };
 }
@@ -402,13 +407,13 @@ export async function runSendQueue(
             skipped_reasons.push(
               buildSkippedSummary(queue_item_id, claim_result?.reason || "queue_item_claim_conflict")
             );
-            results.push({
-              ok: true,
-              skipped: true,
-              reason: claim_result?.reason || "queue_item_claim_conflict",
-              queue_item_id,
-              queue_row_id: queue_item_id,
-            });
+          results.push({
+            ok: true,
+            skipped: true,
+            reason: claim_result?.reason || "queue_item_claim_conflict",
+            queue_item_id,
+            queue_row_id: queue_item_id,
+          });
             continue;
           }
 
@@ -479,8 +484,14 @@ export async function runSendQueue(
 
           results.push({
             ...result,
-            queue_item_id,
-            queue_row_id: queue_item_id,
+            queue_item_id:
+              result?.queue_row_id ??
+              result?.queue_item_id ??
+              queue_item_id,
+            queue_row_id:
+              result?.queue_row_id ??
+              result?.queue_item_id ??
+              queue_item_id,
           });
         } catch (error) {
           partial = true;

--- a/src/lib/domain/queue/run-send-queue.js
+++ b/src/lib/domain/queue/run-send-queue.js
@@ -1,44 +1,17 @@
-import APP_IDS from "@/lib/config/app-ids.js";
-
-import {
-  buildPodioCooldownSkipResult,
-  filterAppItems,
-  getCategoryValue,
-  getDateValue,
-  getFirstAppReferenceId,
-  getNumberValue,
-  isPodioRateLimitError,
-  PodioError,
-} from "@/lib/providers/podio.js";
-
 import {
   failQueueItem,
   processSendQueueItem,
 } from "@/lib/domain/queue/process-send-queue.js";
-import { recordSystemAlert, resolveSystemAlert } from "@/lib/domain/alerts/system-alerts.js";
 import { withRunLock } from "@/lib/domain/runs/run-locks.js";
 import { info, warn } from "@/lib/logging/logger.js";
+import { hasSupabaseConfig } from "@/lib/supabase/client.js";
+import {
+  claimSendQueueRow,
+  loadRunnableSendQueueRows,
+} from "@/lib/supabase/sms-engine.js";
 
 const DEFAULT_BATCH_SIZE = 50;
-const QUEUE_RUN_SCAN_CAP_MULTIPLIER = 4;
-const QUEUE_RUN_PAGE_SIZE_CAP = 100;
-const QUEUE_RUN_SCAN_CAP_MAX = 250;
-const BLOCKED_REASONS = Object.freeze(
-  new Set([
-    "message_resolution_failed",
-    "junk_message_body",
-    "phone_not_active",
-    "destination_number_invalid",
-    "outbound_number_item_missing",
-    "outbound_number_phone_invalid",
-    "phone_post_contact_suppression",
-    "classification_stop_texting",
-  ])
-);
-
-function nowIso() {
-  return new Date().toISOString();
-}
+const QUEUE_RUN_LOCK_SCOPE = "queue-run";
 
 function clean(value) {
   return String(value ?? "").trim();
@@ -48,1013 +21,568 @@ function lower(value) {
   return clean(value).toLowerCase();
 }
 
-function isRevisionLimitExceededError(error) {
-  if (!(error instanceof PodioError)) return false;
-  return lower(error?.message).includes(
-    "this item has exceeded the maximum number of revisions"
-  );
+function asPositiveInteger(value, fallback = null) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : fallback;
 }
 
-async function recordRevisionLimitAlert(
-  record_alert,
-  queue_item_id,
-  {
-    run_started_at,
-    master_owner_id = null,
-    error = null,
-  } = {}
-) {
-  try {
-    await record_alert({
-      subsystem: "queue",
-      code: "revision_limit_exceeded",
-      severity: "warning",
-      retryable: false,
-      summary: `Queue item ${queue_item_id} hit the Podio revision limit and was skipped for manual review.`,
-      dedupe_key: `queue-revision-limit:${queue_item_id}`,
-      affected_ids: [queue_item_id],
-      metadata: {
-        queue_item_id,
-        failure_bucket: "revision_limit_exceeded",
-        run_started_at,
-        master_owner_id,
-        podio_error_message: error?.message || null,
-        recovery: "manual_review_required",
-      },
-    });
-  } catch (alert_error) {
-    warn("queue.run_revision_limit_alert_failed", {
-      queue_item_id,
-      failure_bucket: "revision_limit_exceeded",
-      message: alert_error?.message || "Unknown alert recording error",
-    });
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function normalizeRows(data) {
+  return Array.isArray(data) ? data : [];
+}
+
+function getPlainValue(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== "object") return raw;
+  if ("value" in raw) {
+    const value = raw.value;
+    if (value && typeof value === "object" && "text" in value) return value.text;
+    if (value && typeof value === "object" && "item_id" in value) return value.item_id;
+    return value;
   }
+  if ("start" in raw) return raw.start;
+  return raw;
+}
+
+function getRecordFieldValues(record = null, key = "") {
+  if (!record || typeof record !== "object") return [];
+
+  if (Object.prototype.hasOwnProperty.call(record, key)) {
+    const direct = record[key];
+    return Array.isArray(direct) ? direct : [direct];
+  }
+
+  const fields = Array.isArray(record.fields) ? record.fields : [];
+  const matched = fields.find((field) => clean(field?.external_id) === clean(key));
+  if (!matched) return [];
+  return Array.isArray(matched.values) ? matched.values : [];
+}
+
+function getCategoryLike(record = null, key = "", fallback = null) {
+  const values = getRecordFieldValues(record, key);
+  if (!values.length) return fallback;
+  const first = values[0];
+  if (first?.value?.text) return clean(first.value.text) || fallback;
+  return clean(getPlainValue(first)) || fallback;
+}
+
+function getDateLike(record = null, key = "", fallback = null) {
+  const values = getRecordFieldValues(record, key);
+  if (!values.length) return fallback;
+  return clean(values[0]?.start ?? getPlainValue(values[0])) || fallback;
 }
 
 function toTimestamp(value) {
   if (!value) return null;
-  const ts = new Date(value).getTime();
-  return Number.isNaN(ts) ? null : ts;
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? null : parsed;
 }
 
-function isDue(queue_item, now_ts) {
-  const scheduled_utc =
-    getDateValue(queue_item, "scheduled-for-utc", null) ||
-    getDateValue(queue_item, "scheduled-for-local", null);
+function getQueueRowId(row = null) {
+  return asPositiveInteger(row?.id ?? row?.queue_item_id ?? row?.item_id, null);
+}
 
-  if (!scheduled_utc) return true;
+function getQueueStatus(row = null) {
+  return clean(row?.queue_status || getCategoryLike(row, "queue-status", ""));
+}
 
-  const scheduled_ts = toTimestamp(scheduled_utc);
-  if (scheduled_ts === null) return false;
+function getScheduledAt(row = null) {
+  return (
+    clean(row?.scheduled_for) ||
+    clean(row?.scheduled_for_utc) ||
+    clean(row?.scheduled_for_local) ||
+    clean(getDateLike(row, "scheduled-for-utc", null)) ||
+    clean(getDateLike(row, "scheduled-for-local", null)) ||
+    null
+  );
+}
 
+function isRunnableStatus(row = null) {
+  return lower(getQueueStatus(row)) === "queued";
+}
+
+function isDue(row = null, now = nowIso()) {
+  const scheduled_at = getScheduledAt(row);
+  if (!scheduled_at) return true;
+
+  const scheduled_ts = toTimestamp(scheduled_at);
+  const now_ts = toTimestamp(now);
+
+  if (scheduled_ts === null || now_ts === null) return false;
   return scheduled_ts <= now_ts;
 }
 
-function sortByScheduledAtAsc(items) {
-  return [...items].sort((a, b) => {
-    const a_date =
-      getDateValue(a, "scheduled-for-utc", null) ||
-      getDateValue(a, "scheduled-for-local", null) ||
-      "9999-12-31T23:59:59.999Z";
-
-    const b_date =
-      getDateValue(b, "scheduled-for-utc", null) ||
-      getDateValue(b, "scheduled-for-local", null) ||
-      "9999-12-31T23:59:59.999Z";
-
-    const a_ts = toTimestamp(a_date) ?? Number.MAX_SAFE_INTEGER;
-    const b_ts = toTimestamp(b_date) ?? Number.MAX_SAFE_INTEGER;
-
-    return a_ts - b_ts;
+function sortByScheduledAt(rows = []) {
+  return [...rows].sort((left, right) => {
+    const left_ts = toTimestamp(getScheduledAt(left)) ?? Number.MAX_SAFE_INTEGER;
+    const right_ts = toTimestamp(getScheduledAt(right)) ?? Number.MAX_SAFE_INTEGER;
+    return left_ts - right_ts;
   });
 }
 
-function isRunnableStatus(status) {
-  const normalized = lower(status);
-  return normalized === "queued";
+function isLegacyQueueRow(row = null) {
+  return Boolean(row?.item_id) && !row?.id;
 }
 
-function extractItems(response) {
-  if (Array.isArray(response)) return response;
-  return Array.isArray(response?.items) ? response.items : [];
+export async function loadQueuedItems(limit = 50, deps = {}) {
+  if (typeof deps.loadQueuedItems === "function") {
+    return normalizeRows(await deps.loadQueuedItems(limit));
+  }
+
+  if (typeof deps.fetchAllItems === "function") {
+    return normalizeRows(await deps.fetchAllItems());
+  }
+
+  const result = await loadRunnableSendQueueRows(limit, deps);
+  console.log("SUPABASE QUEUE LOADED", { count: result.rows.length });
+  return result.rows;
 }
 
-function summarizeProblemReason(value) {
-  const normalized = clean(value)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
-  return normalized || "unknown";
+async function buildLegacyCandidateSummary(limit = 50, now = nowIso(), deps = {}) {
+  const loaded_rows = sortByScheduledAt(normalizeRows(await deps.fetchAllItems()));
+  const queued_rows = loaded_rows.filter((row) => isRunnableStatus(row));
+  const due_rows = [];
+  const future_rows = [];
+
+  for (const row of queued_rows) {
+    if (isDue(row, now)) {
+      due_rows.push(row);
+    } else {
+      future_rows.push(row);
+    }
+  }
+
+  const runnable_rows = due_rows.slice(0, limit);
+
+  return {
+    rows: runnable_rows,
+    raw_rows: loaded_rows,
+    total_rows_loaded: loaded_rows.length,
+    queued_rows_loaded: queued_rows.length,
+    due_rows: due_rows.length,
+    future_rows: future_rows.length,
+    outside_window_rows: 0,
+    first_10_candidate_item_ids: runnable_rows
+      .map((row) => getQueueRowId(row))
+      .filter(Boolean)
+      .slice(0, 10),
+    first_10_excluded: future_rows.slice(0, 10).map((row) => ({
+      item_id: getQueueRowId(row),
+      reason: "not_due_yet",
+    })),
+  };
 }
 
-function isBlockedDisposition(result = {}) {
-  const queue_status = lower(result?.queue_status);
-  if (queue_status === "blocked") return true;
+async function buildSupabaseCandidateSummary(limit = 50, now = nowIso(), deps = {}) {
+  const loaded = await loadRunnableSendQueueRows(limit, {
+    ...deps,
+    now,
+  });
 
-  const reason = summarizeProblemReason(result?.reason);
-  if (BLOCKED_REASONS.has(reason)) return true;
-  if (reason.startsWith("outbound_number_inactive")) return true;
-  if (reason.startsWith("outbound_number_paused_until")) return true;
-  if (reason.startsWith("outbound_number_hard_paused")) return true;
+  const rows = normalizeRows(loaded.rows);
+  const raw_rows = normalizeRows(loaded.raw_rows);
+  const skipped = normalizeRows(loaded.skipped);
 
-  return false;
+  return {
+    rows,
+    raw_rows,
+    total_rows_loaded: raw_rows.length,
+    queued_rows_loaded: raw_rows.length,
+    due_rows: rows.length,
+    future_rows: skipped.filter((entry) =>
+      ["scheduled_for_in_future", "next_retry_pending"].includes(entry?.reason)
+    ).length,
+    outside_window_rows: 0,
+    first_10_candidate_item_ids: rows
+      .map((row) => getQueueRowId(row))
+      .filter(Boolean)
+      .slice(0, 10),
+    first_10_excluded: skipped.slice(0, 10).map((entry) => ({
+      item_id: asPositiveInteger(entry?.id, null),
+      reason: entry?.reason || "excluded",
+    })),
+  };
 }
 
-function classifyQueueRunItemResult(result = {}) {
+async function buildQueueCandidates(limit = 50, now = nowIso(), deps = {}) {
+  if (typeof deps.fetchAllItems === "function") {
+    return buildLegacyCandidateSummary(limit, now, deps);
+  }
+
+  return buildSupabaseCandidateSummary(limit, now, deps);
+}
+
+function classifyRunResult(result = {}) {
+  if (result?.skipped && result?.reason === "queue_item_claim_conflict") {
+    return { disposition: "duplicate_locked", reason: "queue_item_claim_conflict" };
+  }
+
+  if (result?.reason === "outside_contact_window") {
+    return { disposition: "blocked", reason: "outside_contact_window" };
+  }
+
   if (result?.skipped) {
     return {
       disposition: "skipped",
-      reason: summarizeProblemReason(result.reason || "skipped"),
+      reason: clean(result?.reason) || "skipped",
     };
   }
 
-  if (result?.sent) {
-    return {
-      disposition: "sent",
-      reason: summarizeProblemReason(result.reason || "sent"),
-    };
-  }
-
-  if (isBlockedDisposition(result)) {
+  if (lower(result?.queue_status) === "blocked") {
     return {
       disposition: "blocked",
-      reason: summarizeProblemReason(result.reason || "blocked"),
+      reason: clean(result?.reason) || "blocked",
     };
   }
 
-  if (result?.ok) {
+  if (
+    result?.sent ||
+    clean(result?.provider_message_id) ||
+    clean(result?.message_id) ||
+    clean(result?.sid)
+  ) {
     return {
       disposition: "sent",
-      reason: summarizeProblemReason(result.reason || "ok"),
+      reason: clean(result?.reason) || "sent",
     };
   }
 
-  return {
-    disposition: "failed",
-    reason: summarizeProblemReason(result.reason || "failed"),
-  };
-}
-
-function wasQueueItemClaimed(result = {}, classification = null) {
-  if (typeof result?.claimed === "boolean") {
-    return result.claimed;
-  }
-
-  const resolved_classification =
-    classification || classifyQueueRunItemResult(result);
-
-  if (resolved_classification.disposition === "skipped") {
-    return false;
-  }
-
-  if (result?.sent) {
-    return true;
-  }
-
-  if (clean(result?.provider_message_id) || clean(result?.message_id)) {
-    return true;
-  }
-
-  return false;
-}
-
-async function loadQueuedItemsWindow({
-  limit,
-  filter_app_items,
-}) {
-  const page_size = Math.min(
-    Math.max(Number(limit || 0) * 2, DEFAULT_BATCH_SIZE),
-    QUEUE_RUN_PAGE_SIZE_CAP
-  );
-  const scan_cap = Math.min(
-    Math.max(Number(limit || 0) * QUEUE_RUN_SCAN_CAP_MULTIPLIER, page_size),
-    QUEUE_RUN_SCAN_CAP_MAX
-  );
-  const items = [];
-  let offset = 0;
-  let page_count = 0;
-
-  while (items.length < scan_cap) {
-    const response = await filter_app_items(
-      APP_IDS.send_queue,
-      {
-        "queue-status": "Queued",
-      },
-      {
-        limit: Math.min(page_size, scan_cap - items.length),
-        offset,
-        sort_by: "scheduled-for-utc",
-        sort_desc: false,
-        cache_ttl_ms: 15_000,
-      }
-    );
-    const page_items = extractItems(response);
-    page_count += 1;
-
-    if (!page_items.length) break;
-
-    items.push(...page_items);
-
-    if (page_items.length < page_size) break;
-    offset += page_items.length;
-  }
-
-  return {
-    items,
-    page_size,
-    page_count,
-    scan_cap,
-  };
-}
-
-function mapTimezoneToIana(value) {
-  const raw = lower(value);
-
-  if (raw === "eastern" || raw === "et" || raw === "est" || raw === "edt") {
-    return "America/New_York";
-  }
-
-  if (raw === "central" || raw === "ct" || raw === "cst" || raw === "cdt") {
-    return "America/Chicago";
-  }
-
-  if (raw === "mountain" || raw === "mt" || raw === "mst" || raw === "mdt") {
-    return "America/Denver";
-  }
-
-  if (raw === "pacific" || raw === "pt" || raw === "pst" || raw === "pdt") {
-    return "America/Los_Angeles";
-  }
-
-  if (raw === "alaska") {
-    return "America/Anchorage";
-  }
-
-  if (raw === "hawaii") {
-    return "Pacific/Honolulu";
-  }
-
-  return "America/Chicago";
-}
-
-function getLocalParts(date, timezone) {
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    hour12: false,
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-
-  const parts = formatter.formatToParts(date);
-  const get = (type) => parts.find((p) => p.type === type)?.value || "00";
-
-  const hour = Number(get("hour"));
-  const minute = Number(get("minute"));
-
-  return {
-    hour,
-    minute,
-    minutes_since_midnight: hour * 60 + minute,
-  };
-}
-
-function parseTimeToken(token) {
-  const raw = clean(token).toUpperCase();
-  const match = raw.match(/^(\d{1,2})(?::(\d{2}))?\s*(AM|PM)$/);
-
-  if (!match) return null;
-
-  let hour = Number(match[1]);
-  const minute = Number(match[2] || "0");
-  const meridiem = match[3];
-
-  if (hour === 12) hour = 0;
-  if (meridiem === "PM") hour += 12;
-
-  return hour * 60 + minute;
-}
-
-function parseContactWindow(window_value) {
-  const raw = clean(window_value);
-  if (!raw) return null;
-
-  const normalized = raw.toUpperCase();
-
-  const range_match = normalized.match(
-    /(\d{1,2}(?::\d{2})?\s*(?:AM|PM))\s*-\s*(\d{1,2}(?::\d{2})?\s*(?:AM|PM))/
-  );
-
-  if (!range_match) return null;
-
-  const start = parseTimeToken(range_match[1]);
-  const end = parseTimeToken(range_match[2]);
-
-  if (start === null || end === null) return null;
-
-  return { start, end };
-}
-
-function isWithinContactWindow(queue_item, now_date) {
-  const timezone_label = getCategoryValue(queue_item, "timezone", "Central");
-  const contact_window = getCategoryValue(queue_item, "contact-window", null);
-
-  if (!contact_window) {
+  if (result?.ok === false) {
     return {
-      allowed: true,
-      timezone_label,
-      contact_window: null,
-      reason: "no_contact_window",
+      disposition: "failed",
+      reason: clean(result?.reason) || "failed",
     };
   }
-
-  const parsed_window = parseContactWindow(contact_window);
-  if (!parsed_window) {
-    return {
-      allowed: true,
-      timezone_label,
-      contact_window,
-      reason: "unparseable_contact_window",
-    };
-  }
-
-  const timezone = mapTimezoneToIana(timezone_label);
-  const local = getLocalParts(now_date, timezone);
-
-  const { start, end } = parsed_window;
-  const current = local.minutes_since_midnight;
-
-  const allowed =
-    end >= start
-      ? current >= start && current <= end
-      : current >= start || current <= end;
 
   return {
-    allowed,
-    timezone_label,
-    timezone,
-    contact_window,
-    local_minutes_since_midnight: current,
-    reason: allowed ? "inside_window" : "outside_window",
+    disposition: "sent",
+    reason: clean(result?.reason) || "ok",
   };
 }
 
-export async function runSendQueue({
-  limit = DEFAULT_BATCH_SIZE,
-  now = null,
-  dry_run = false,
-  master_owner_id = null,
-} = {}, deps = {}) {
-  const fetch_all_items = deps.fetchAllItems || null;
-  const filter_app_items = deps.filterAppItems || filterAppItems;
+function buildSkippedSummary(queue_item_id, reason) {
+  return {
+    queue_item_id,
+    reason,
+  };
+}
+
+export async function runSendQueue(
+  {
+    limit = DEFAULT_BATCH_SIZE,
+    dry_run = false,
+    now = nowIso(),
+  } = {},
+  deps = {}
+) {
+  const with_run_lock = deps.withRunLock || withRunLock;
   const process_send_queue_item =
     deps.processSendQueueItem || processSendQueueItem;
   const fail_queue_item = deps.failQueueItem || failQueueItem;
-  const record_system_alert = deps.recordSystemAlert || recordSystemAlert;
-  const resolve_system_alert = deps.resolveSystemAlert || resolveSystemAlert;
-  const with_run_lock = deps.withRunLock || withRunLock;
-  const build_cooldown_skip_result =
-    deps.buildPodioCooldownSkipResult || buildPodioCooldownSkipResult;
-  const info_log = deps.info || info;
-  const warn_log = deps.warn || warn;
-  const run_started_at = now || nowIso();
-  const batch_started_ms = Date.now();
-  const now_ts = toTimestamp(run_started_at) ?? Date.now();
-  const now_date = new Date(run_started_at);
-  const scoped_master_owner_id = Number(master_owner_id || 0) || null;
+  const claim_send_queue_row = deps.claimSendQueueRow || claimSendQueueRow;
+  const log_info = deps.info || info;
+  const log_warn = deps.warn || warn;
+  const run_started_at = now;
 
-  const cooldown_skip = await build_cooldown_skip_result({
-    dry_run,
-    run_started_at,
-    limit,
-    master_owner_id: scoped_master_owner_id,
-    total_rows_loaded: 0,
-    queued_rows_loaded: 0,
-    due_rows: 0,
-    future_rows: 0,
-    outside_window_rows: 0,
-    attempted_count: 0,
-    claimed_count: 0,
-    started_count: 0,
-    processed_count: 0,
-    sent_count: 0,
-    failed_count: 0,
-    blocked_count: 0,
-    skipped_count: 0,
-    duplicate_locked_count: 0,
-    first_failure_queue_item_id: null,
-    first_failure_reason: null,
-    batch_duration_ms: 0,
-    results: [],
-  });
-
-  if (cooldown_skip?.podio_cooldown?.active) {
-    warn_log("queue.run_skipped_podio_cooldown", {
-      run_started_at,
+  return with_run_lock({
+    scope: QUEUE_RUN_LOCK_SCOPE,
+    owner: "queue_runner",
+    metadata: {
       limit,
       dry_run,
-      master_owner_id: scoped_master_owner_id,
-      retry_after_seconds: cooldown_skip.retry_after_seconds,
-      retry_after_at: cooldown_skip.retry_after_at,
-      podio_status: cooldown_skip.podio_cooldown?.status ?? null,
-      podio_path: cooldown_skip.podio_cooldown?.path ?? null,
-      podio_operation: cooldown_skip.podio_cooldown?.operation ?? null,
-      rate_limit_remaining:
-        cooldown_skip.podio_cooldown?.rate_limit_remaining ?? null,
-      rate_limit_limit:
-        cooldown_skip.podio_cooldown?.rate_limit_limit ?? null,
-    });
-
-    return cooldown_skip;
-  }
-
-  async function executeRun() {
-    info_log("queue.run_started", {
-      limit,
       run_started_at,
+    },
+    onLocked: async (lock) => ({
+      ok: true,
+      skipped: true,
+      reason: "queue_runner_lock_active",
       dry_run,
-      master_owner_id: scoped_master_owner_id,
-    });
-
-    info_log("queue.run_fetch_started", {
-      send_queue_app_id: APP_IDS.send_queue,
-      filter: { "queue-status": "Queued" },
-      page_size: fetch_all_items
-        ? Math.max(limit, 50)
-        : Math.min(Math.max(limit * 2, DEFAULT_BATCH_SIZE), QUEUE_RUN_PAGE_SIZE_CAP),
-      sort_by: "scheduled-for-utc",
+      lock,
+      attempted_count: 0,
+      claimed_count: 0,
+      started_count: 0,
+      processed_count: 0,
+      sent_count: 0,
+      failed_count: 0,
+      blocked_count: 0,
+      skipped_count: 0,
+      duplicate_locked_count: 0,
+      total_rows_loaded: 0,
+      queued_rows_loaded: 0,
+      due_rows: 0,
+      future_rows: 0,
+      batch_duration_ms: 0,
       run_started_at,
-      loader: fetch_all_items ? "fetch_all_items" : "paged_filter_window",
-    });
-
-    const queue_window = fetch_all_items
-      ? {
-          items: await fetch_all_items(
-            APP_IDS.send_queue,
-            {
-              "queue-status": "Queued",
-            },
-            {
-              page_size: Math.max(limit, 50),
-              sort_by: "scheduled-for-utc",
-              sort_desc: false,
-            }
-          ),
-          page_size: Math.max(limit, 50),
-          page_count: null,
-          scan_cap: null,
-        }
-      : await loadQueuedItemsWindow({
-          limit,
-          filter_app_items,
-        });
-
-    const queued_items = queue_window.items;
-
-    let future_rows_count = 0;
-    let outside_window_count = 0;
-    const filter_diagnostics = [];
-
-    const all_due_runnable = queued_items.filter((item) => {
-      const item_id = item?.item_id;
-      const status = getCategoryValue(item, "queue-status", null);
-
-      if (!isRunnableStatus(status)) {
-        if (filter_diagnostics.length < 10) {
-          filter_diagnostics.push({ item_id, reason: "bad_status", status });
-        }
-        return false;
-      }
-
-      if (
-        scoped_master_owner_id &&
-        Number(getFirstAppReferenceId(item, "master-owner", 0) || 0) !==
-          scoped_master_owner_id
-      ) {
-        if (filter_diagnostics.length < 10) {
-          filter_diagnostics.push({ item_id, reason: "scoped_mismatch" });
-        }
-        return false;
-      }
-
-      if (!isDue(item, now_ts)) {
-        future_rows_count += 1;
-        const scheduled =
-          getDateValue(item, "scheduled-for-utc", null) ||
-          getDateValue(item, "scheduled-for-local", null);
-        if (filter_diagnostics.length < 10) {
-          filter_diagnostics.push({ item_id, reason: "not_due_yet", scheduled });
-        }
-        return false;
-      }
-
-      const contact_window_check = isWithinContactWindow(item, now_date);
-      if (!contact_window_check.allowed) {
-        outside_window_count += 1;
-        if (filter_diagnostics.length < 10) {
-          filter_diagnostics.push({
-            item_id,
-            reason: "outside_contact_window",
-            timezone: contact_window_check.timezone_label,
-            contact_window: contact_window_check.contact_window,
-            local_minutes_since_midnight: contact_window_check.local_minutes_since_midnight,
-          });
-        }
-        return false;
-      }
-
-      return true;
-    });
-
-    const sorted_candidates = sortByScheduledAtAsc(all_due_runnable).slice(0, limit);
-
-    // Within-batch duplicate guard: if the same (master_owner_id, phone_item_id,
-    // touch_number) appears more than once in the batch, only the earliest-
-    // scheduled item is processed.  Duplicates are skipped with a warning so
-    // the operator can investigate why multiple queue rows exist for the same
-    // send target and touch sequence.
-    const seen_send_keys = new Set();
-    const batch_duplicate_details = [];
-
-    const runnable_items = sorted_candidates.filter((item) => {
-      const owner_id = getFirstAppReferenceId(item, "master-owner", null);
-      const phone_id = getFirstAppReferenceId(item, "phone-number", null);
-      const touch_num = getNumberValue(item, "touch-number", null);
-
-      if (owner_id && phone_id && touch_num !== null) {
-        const dedup_key = `${owner_id}:${phone_id}:${touch_num}`;
-        if (seen_send_keys.has(dedup_key)) {
-          batch_duplicate_details.push({
-            item_id: item?.item_id,
-            owner_id,
-            phone_id,
-            touch_num,
-            reason: "duplicate_owner_phone_touch_in_batch",
-          });
-          return false;
-        }
-        seen_send_keys.add(dedup_key);
-      }
-      return true;
-    });
-
-    if (batch_duplicate_details.length > 0) {
-      warn_log("queue.run_batch_duplicates_suppressed", {
-        duplicate_count: batch_duplicate_details.length,
-        first_5_duplicates: batch_duplicate_details.slice(0, 5),
-        run_started_at,
-      });
-    }
-
-    info_log("queue.run_candidates_loaded", {
-      now_utc: run_started_at,
-      total_rows_loaded: queued_items.length,
-      queued_rows_loaded: queued_items.length,
-      due_rows: all_due_runnable.length,
-      future_rows: future_rows_count,
-      outside_window_rows: outside_window_count,
-      runnable_count: runnable_items.length,
-      queue_pages_loaded: queue_window.page_count,
-      queue_scan_cap: queue_window.scan_cap,
-      master_owner_id: scoped_master_owner_id,
-      first_10_candidate_item_ids: runnable_items.slice(0, 10).map((i) => i?.item_id),
-      first_10_filter_excluded: filter_diagnostics,
-    });
-
-    if (dry_run) {
-      const summary = {
-        ok: true,
-        dry_run: true,
-        run_started_at,
-        total_rows_loaded: queued_items.length,
-        queued_rows_loaded: queued_items.length,
-        due_rows: all_due_runnable.length,
-        future_rows: future_rows_count,
-        outside_window_rows: outside_window_count,
-        first_10_candidate_item_ids: runnable_items.slice(0, 10).map((i) => i?.item_id),
-        first_10_excluded: filter_diagnostics,
-        attempted_count: runnable_items.length,
-        claimed_count: 0,
-        started_count: runnable_items.length,
-        processed_count: runnable_items.length,
-        sent_count: 0,
-        failed_count: 0,
-        blocked_count: 0,
-        skipped_count: 0,
-        duplicate_locked_count: 0,
-        first_failing_queue_item_id: null,
-        first_failing_reason: null,
-        first_failure_queue_item_id: null,
-        first_failure_reason: null,
-        batch_duration_ms: Date.now() - batch_started_ms,
-        master_owner_id: scoped_master_owner_id,
-        results: runnable_items.map((item) => ({
-          queue_item_id: item?.item_id || null,
-          ok: true,
-          dry_run: true,
-          action: "would_process",
-        })),
-      };
-
-      info_log("queue.run_completed", {
-        now_utc: run_started_at,
-        run_started_at,
-        total_rows_loaded: queued_items.length,
-        queued_rows_loaded: queued_items.length,
-        due_rows: all_due_runnable.length,
-        future_rows: future_rows_count,
-        outside_window_rows: outside_window_count,
-        runnable_count: runnable_items.length,
-        attempted_count: summary.attempted_count,
-        claimed_count: summary.claimed_count,
-        started_count: summary.started_count,
-        processed_count: summary.processed_count,
-        sent_rows: 0,
-        sent_count: 0,
-        blocked_rows: 0,
-        blocked_count: 0,
-        failed_count: 0,
-        skipped_rows: 0,
-        skipped_count: 0,
-        duplicate_locked_count: 0,
-        batch_duration_ms: summary.batch_duration_ms,
-        dry_run: true,
-        master_owner_id: scoped_master_owner_id,
-        first_10_candidate_item_ids: runnable_items.slice(0, 10).map((i) => i?.item_id),
-        first_10_skipped_item_ids_with_reason: [],
+      results: [],
+    }),
+    fn: async () => {
+      console.log("QUEUE START");
+      console.log("ENV CHECK", {
+        supabase_configured: hasSupabaseConfig(),
+        textgrid_account_sid_present: Boolean(clean(process.env.TEXTGRID_ACCOUNT_SID)),
+        textgrid_auth_token_present: Boolean(clean(process.env.TEXTGRID_AUTH_TOKEN)),
       });
 
-      return summary;
-    }
+      const started_at_ms = Date.now();
+      const candidate_summary = await buildQueueCandidates(limit, now, deps);
+      const rows = candidate_summary.rows;
 
-    const results = [];
-    let attempted_count = 0;
-    let claimed_count = 0;
-    let started_count = 0;
-    let processed_count = 0;
-    let sent_count = 0;
-    let failed_count = 0;
-    let skipped_count = 0;
-    let blocked_count = 0;
-    let duplicate_locked_count = 0;
-    const skipped_details = [];
-    let first_failing_queue_item_id = null;
-    let first_failing_reason = null;
+      console.log("ROWS LOADED", {
+        total_rows_loaded: candidate_summary.total_rows_loaded,
+        runnable_count: rows.length,
+      });
+      console.log("RAW ROWS", candidate_summary.raw_rows);
 
-    for (const item of runnable_items) {
-      const queue_item_id = item?.item_id;
-      attempted_count += 1;
-      started_count += 1;
-
-      info_log("queue.run_item_started", {
-        queue_item_id,
-        run_started_at,
-        master_owner_id: scoped_master_owner_id,
+      log_info("queue.run_candidates_loaded", {
+        total_rows_loaded: candidate_summary.total_rows_loaded,
+        queued_rows_loaded: candidate_summary.queued_rows_loaded,
+        due_rows: candidate_summary.due_rows,
+        future_rows: candidate_summary.future_rows,
+        runnable_count: rows.length,
+        now_utc: now,
+        first_10_candidate_item_ids: candidate_summary.first_10_candidate_item_ids,
+        first_10_filter_excluded: candidate_summary.first_10_excluded,
       });
 
-      try {
-        const result = await process_send_queue_item(queue_item_id);
-        processed_count += 1;
-        const classification = classifyQueueRunItemResult(result);
-        if (wasQueueItemClaimed(result, classification)) {
-          claimed_count += 1;
-        }
+      const results = [];
+      const skipped_reasons = [];
+      let attempted_count = 0;
+      let claimed_count = 0;
+      let started_count = 0;
+      let processed_count = 0;
+      let sent_count = 0;
+      let failed_count = 0;
+      let blocked_count = 0;
+      let skipped_count = 0;
+      let duplicate_locked_count = 0;
+      let partial = false;
+      let first_failing_queue_item_id = null;
+      let first_failing_reason = null;
+      let first_failure_queue_item_id = null;
+      let first_failure_reason = null;
 
-        results.push({
-          queue_item_id,
-          ...result,
-        });
+      for (const row of rows) {
+        const queue_item_id = getQueueRowId(row);
+        const legacy_mode = isLegacyQueueRow(row);
+        let queue_row = row;
+        let lock_token = clean(deps.claimedLockToken) || null;
 
-        if (classification.disposition === "skipped") {
-          skipped_count += 1;
-          if (result?.claim_conflict || classification.reason === "queue_item_claim_conflict") {
-            duplicate_locked_count += 1;
-          }
-          if (skipped_details.length < 10) {
-            skipped_details.push({
-              queue_item_id,
-              reason: classification.reason,
-            });
-          }
-        } else if (classification.disposition === "sent") {
-          sent_count += 1;
-        } else {
-          if (classification.disposition === "blocked") {
-            blocked_count += 1;
-          } else {
-            failed_count += 1;
-          }
+        started_count += 1;
+        attempted_count += 1;
 
-          if (!first_failing_queue_item_id) {
-            first_failing_queue_item_id = queue_item_id || null;
-            first_failing_reason = classification.reason;
-          }
+        console.log("PROCESSING ROW", queue_item_id);
 
-          warn_log("queue.run_item_failed_soft", {
-            queue_item_id,
-            reason: classification.reason,
-            queue_status: result?.queue_status || null,
-            failed_reason: result?.failed_reason || null,
-            details: result.details || null,
-          });
-          if (skipped_details.length < 10) {
-            skipped_details.push({
-              queue_item_id,
-              reason: classification.reason,
-            });
-          }
-        }
-
-        info_log("queue.run_item_completed", {
-          queue_item_id,
-          disposition: classification.disposition,
-          reason: classification.reason,
-          queue_status: result?.queue_status || null,
-          failed_reason: result?.failed_reason || null,
-          sent: Boolean(result?.sent),
-          skipped: Boolean(result?.skipped),
-        });
-      } catch (err) {
-        if (isPodioRateLimitError(err)) {
-          warn_log("queue.run_rate_limit_abort", {
-            queue_item_id,
-            message: err?.message || "Podio cooldown active",
-          });
-          throw err;
-        }
-
-        if (isRevisionLimitExceededError(err)) {
-          warn_log("queue.run_item_skipped_revision_limit", {
-            queue_item_id,
-            failure_bucket: "revision_limit_exceeded",
-            message: err?.message || "Unknown queue processing error",
-          });
-
+        if (dry_run) {
           processed_count += 1;
           skipped_count += 1;
-          if (skipped_details.length < 10) {
-            skipped_details.push({ queue_item_id, reason: "revision_limit_exceeded" });
-          }
+          skipped_reasons.push(buildSkippedSummary(queue_item_id, "dry_run"));
           results.push({
-            queue_item_id,
             ok: true,
             skipped: true,
-            reason: "queue_item_revision_limit_exceeded",
-            failure_bucket: "revision_limit_exceeded",
-            manual_review_required: true,
-          });
-
-          await recordRevisionLimitAlert(record_system_alert, queue_item_id, {
-            run_started_at,
-            master_owner_id: scoped_master_owner_id,
-            error: err,
+            dry_run: true,
+            queue_item_id,
+            queue_row_id: queue_item_id,
+            reason: "dry_run",
           });
           continue;
         }
 
-        const machine_reason = "queue_processing_exception";
-        const error_message = err?.message || "Unknown queue processing error";
-        let crash_mark_applied = false;
+        if (!legacy_mode) {
+          const claim_result = await claim_send_queue_row(queue_row, {
+            ...deps,
+            now,
+          });
+
+          if (!claim_result?.claimed) {
+            duplicate_locked_count += 1;
+            skipped_count += 1;
+            skipped_reasons.push(
+              buildSkippedSummary(queue_item_id, claim_result?.reason || "queue_item_claim_conflict")
+            );
+            results.push({
+              ok: true,
+              skipped: true,
+              reason: claim_result?.reason || "queue_item_claim_conflict",
+              queue_item_id,
+              queue_row_id: queue_item_id,
+            });
+            continue;
+          }
+
+          claimed_count += 1;
+          queue_row = claim_result.row || queue_row;
+          lock_token = claim_result.lock_token || lock_token;
+        }
 
         try {
-          await fail_queue_item(queue_item_id, {
-            queue_status: "Failed",
-            failed_reason: "Network Error",
-            _phase: "queue_run_item_crashed",
-          });
-          crash_mark_applied = true;
-        } catch (mark_error) {
-          warn_log("queue.run_item_crash_mark_failed", {
+          const result = await process_send_queue_item(
+            legacy_mode ? queue_item_id : queue_row,
+            {
+              ...deps,
+              now,
+              claimedLockToken: lock_token,
+            }
+          );
+          processed_count += 1;
+          const classification = classifyRunResult(result);
+
+          if (classification.disposition === "sent") {
+            if (legacy_mode) claimed_count += 1;
+            sent_count += 1;
+          }
+
+          if (classification.disposition === "failed") {
+            partial = true;
+            failed_count += 1;
+            skipped_reasons.push(
+              buildSkippedSummary(queue_item_id, classification.reason)
+            );
+            log_warn("queue.run_item_failed_soft", {
+              queue_item_id,
+              reason: classification.reason,
+            });
+
+            if (!first_failing_queue_item_id) {
+              first_failing_queue_item_id = queue_item_id;
+              first_failing_reason = classification.reason;
+            }
+            if (!first_failure_queue_item_id) {
+              first_failure_queue_item_id = queue_item_id;
+              first_failure_reason = classification.reason;
+            }
+          }
+
+          if (classification.disposition === "blocked") {
+            blocked_count += 1;
+            skipped_reasons.push(
+              buildSkippedSummary(queue_item_id, classification.reason)
+            );
+          }
+
+          if (classification.disposition === "skipped") {
+            skipped_count += 1;
+            skipped_reasons.push(
+              buildSkippedSummary(queue_item_id, classification.reason)
+            );
+          }
+
+          if (classification.disposition === "duplicate_locked") {
+            duplicate_locked_count += 1;
+            skipped_count += 1;
+            skipped_reasons.push(
+              buildSkippedSummary(queue_item_id, classification.reason)
+            );
+          }
+
+          results.push({
+            ...result,
             queue_item_id,
-            reason: machine_reason,
-            message: mark_error?.message || "Unknown queue crash write failure",
+            queue_row_id: queue_item_id,
+          });
+        } catch (error) {
+          partial = true;
+          processed_count += 1;
+          failed_count += 1;
+
+          if (!first_failing_queue_item_id) {
+            first_failing_queue_item_id = queue_item_id;
+            first_failing_reason = "queue_processing_exception";
+          }
+          if (!first_failure_queue_item_id) {
+            first_failure_queue_item_id = queue_item_id;
+            first_failure_reason = "queue_processing_exception";
+          }
+
+          try {
+            const fail_payload = {
+              queue_status: legacy_mode ? "Failed" : "failed",
+              failed_reason: "Network Error",
+              retry_count: Number(queue_row?.retry_count || 0) + 1,
+            };
+
+            if (legacy_mode && deps.failQueueItem) {
+              await fail_queue_item(queue_item_id, fail_payload);
+            } else {
+              await fail_queue_item(queue_row, fail_payload, {
+                ...deps,
+                now,
+                lock_token: lock_token || queue_row?.lock_token || null,
+              });
+            }
+          } catch (update_error) {
+            log_warn("queue.run_crash_fail_update_failed", {
+              queue_item_id,
+              message: update_error?.message || "Unknown queue fail update error",
+            });
+          }
+
+          log_warn("queue.run_item_crashed", {
+            queue_item_id,
+            reason: "queue_processing_exception",
+            message: error?.message || "Unknown queue processing error",
+          });
+
+          skipped_reasons.push(
+            buildSkippedSummary(queue_item_id, "queue_processing_exception")
+          );
+
+          results.push({
+            ok: false,
+            sent: false,
+            queue_status: "failed",
+            reason: "queue_processing_exception",
+            failed_reason: clean(error?.message) || "queue_processing_exception",
+            queue_item_id,
+            queue_row_id: queue_item_id,
           });
         }
-
-        warn_log("queue.run_item_crashed", {
-          queue_item_id,
-          reason: machine_reason,
-          message: error_message,
-          crash_mark_applied,
-        });
-
-        failed_count += 1;
-        processed_count += 1;
-        if (!first_failing_queue_item_id) {
-          first_failing_queue_item_id = queue_item_id || null;
-          first_failing_reason = machine_reason;
-        }
-        if (skipped_details.length < 10) {
-          skipped_details.push({ queue_item_id, reason: machine_reason });
-        }
-        results.push({
-          queue_item_id,
-          ok: false,
-          sent: false,
-          queue_status: "Failed",
-          failed_reason: "Network Error",
-          reason: machine_reason,
-          error_message,
-          crash_mark_applied,
-        });
       }
-    }
 
-    const partial_failure = failed_count > 0 || blocked_count > 0;
-    const summary = {
-      ok: true,
-      dry_run: false,
-      partial: partial_failure,
-      run_started_at,
-      total_rows_loaded: queued_items.length,
-      queued_rows_loaded: queued_items.length,
-      due_rows: all_due_runnable.length,
-      future_rows: future_rows_count,
-      outside_window_rows: outside_window_count,
-      first_10_candidate_item_ids: runnable_items.slice(0, 10).map((i) => i?.item_id),
-      first_10_excluded: filter_diagnostics,
-      attempted_count,
-      claimed_count,
-      started_count,
-      processed_count,
-      sent_count,
-      failed_count,
-      blocked_count,
-      skipped_count,
-      duplicate_locked_count,
-      first_failing_queue_item_id,
-      first_failing_reason,
-      first_failure_queue_item_id: first_failing_queue_item_id,
-      first_failure_reason: first_failing_reason,
-      batch_duration_ms: Date.now() - batch_started_ms,
-      master_owner_id: scoped_master_owner_id,
-      results,
-    };
-
-    if (partial_failure) {
-      try {
-        await record_system_alert({
-          subsystem: "queue",
-          code: "runner_failed_items",
-          severity: "warning",
-          retryable: true,
-          summary: `Queue runner completed with ${failed_count} failed item(s) and ${blocked_count} blocked item(s).`,
-          dedupe_key: scoped_master_owner_id
-            ? `queue-run:${scoped_master_owner_id}`
-            : "queue-run",
-          affected_ids: results
-            .filter(
-              (result) =>
-                result?.ok === false ||
-                lower(result?.queue_status) === "blocked"
-            )
-            .map((result) => result?.queue_item_id),
-          metadata: {
-            run_started_at,
-            attempted_count,
-            claimed_count,
-            started_count: summary.started_count,
-            processed_count: summary.processed_count,
-            failed_count,
-            blocked_count,
-            sent_count,
-            skipped_count,
-            duplicate_locked_count,
-            first_failing_queue_item_id,
-            first_failing_reason,
-            master_owner_id: scoped_master_owner_id,
-          },
-        });
-      } catch (alert_err) {
-        warn_log("queue.run_system_alert_write_failed", {
-          run_started_at,
-          operation: "record_failed_items_alert",
-          failure_bucket: isRevisionLimitExceededError(alert_err)
-            ? "revision_limit_exceeded"
-            : "write_error",
-          message: alert_err?.message || null,
-        });
-      }
-    } else {
-      try {
-        await resolve_system_alert({
-          subsystem: "queue",
-          code: "runner_failed_items",
-          dedupe_key: scoped_master_owner_id
-            ? `queue-run:${scoped_master_owner_id}`
-            : "queue-run",
-          resolution_message: "Queue runner completed without failed items.",
-        });
-      } catch (alert_err) {
-        warn_log("queue.run_system_alert_write_failed", {
-          run_started_at,
-          operation: "resolve_failed_items_alert",
-          failure_bucket: isRevisionLimitExceededError(alert_err)
-            ? "revision_limit_exceeded"
-            : "write_error",
-          message: alert_err?.message || null,
-        });
-      }
-    }
-
-    info_log("queue.run_completed", {
-      now_utc: run_started_at,
-      run_started_at,
-      total_rows_loaded: queued_items.length,
-      queued_rows_loaded: queued_items.length,
-      due_rows: all_due_runnable.length,
-      future_rows: future_rows_count,
-      outside_window_rows: outside_window_count,
-      runnable_count: runnable_items.length,
-      attempted_count: summary.attempted_count,
-      claimed_count: summary.claimed_count,
-      started_count: summary.started_count,
-      processed_count: summary.processed_count,
-      sent_rows: sent_count,
-      sent_count,
-      blocked_rows: blocked_count,
-      blocked_count,
-      failed_count,
-      skipped_rows: skipped_count,
-      skipped_count,
-      duplicate_locked_count,
-      first_failing_queue_item_id,
-      first_failing_reason,
-      first_failure_queue_item_id: first_failing_queue_item_id,
-      first_failure_reason: first_failing_reason,
-      batch_duration_ms: summary.batch_duration_ms,
-      partial: partial_failure,
-      master_owner_id: scoped_master_owner_id,
-      first_10_candidate_item_ids: runnable_items.slice(0, 10).map((i) => i?.item_id),
-      first_10_skipped_item_ids_with_reason: skipped_details,
-    });
-
-    return summary;
-  }
-
-  return with_run_lock({
-    scope: scoped_master_owner_id
-      ? `queue-run:${scoped_master_owner_id}`
-      : "queue-run",
-    enabled: !dry_run,
-    lease_ms: 10 * 60_000,
-    owner: "queue_runner",
-    metadata: {
-      limit,
-      master_owner_id: scoped_master_owner_id,
-    },
-    onLocked: async (lock) => {
-      warn_log("queue.run_skipped_lock_active", {
-        reason: "queue_runner_lock_active",
-        lock_scope: lock?.scope || null,
-        lock_record_item_id: lock?.record_item_id || null,
-        lock_lease_token: lock?.meta?.lease_token || null,
-        lock_expires_at: lock?.meta?.expires_at || null,
-        lock_owner: lock?.meta?.owner || null,
-        lock_acquired_at: lock?.meta?.acquired_at || null,
-        lock_acquisition_count: lock?.meta?.acquisition_count ?? null,
+      const batch_duration_ms = Date.now() - started_at_ms;
+      const summary = {
+        ok: true,
+        partial,
+        dry_run,
+        skipped: false,
+        reason: null,
+        attempted_count,
+        claimed_count,
+        started_count,
+        processed_count,
+        sent_count,
+        failed_count,
+        blocked_count,
+        skipped_count,
+        duplicate_locked_count,
+        first_failing_queue_item_id,
+        first_failing_reason,
+        first_failure_queue_item_id,
+        first_failure_reason,
+        batch_duration_ms,
+        total_rows_loaded: candidate_summary.total_rows_loaded,
+        queued_rows_loaded: candidate_summary.queued_rows_loaded,
+        due_rows: candidate_summary.due_rows,
+        future_rows: candidate_summary.future_rows,
+        outside_window_rows: blocked_count || candidate_summary.outside_window_rows,
+        first_10_candidate_item_ids: candidate_summary.first_10_candidate_item_ids,
+        first_10_excluded: candidate_summary.first_10_excluded,
         run_started_at,
-        recovery_hint: "If this persists beyond the expires_at time, the lock is stuck. Call forceReleaseStaleLock({ scope }) to recover.",
+        results,
+      };
+
+      log_info("queue.run_completed", {
+        ...summary,
+        sent_rows: sent_count,
+        blocked_rows: blocked_count,
+        now_utc: now,
+        first_10_skipped_item_ids_with_reason: skipped_reasons.slice(0, 10),
       });
 
-      try {
-        await record_system_alert({
-          subsystem: "queue",
-          code: "runner_overlap",
-          severity: "warning",
-          retryable: true,
-          summary: "Queue runner skipped because an active lease is already in progress.",
-          dedupe_key: scoped_master_owner_id
-            ? `queue-run:${scoped_master_owner_id}`
-            : "queue-run",
-          metadata: {
-            run_started_at,
-            limit,
-            master_owner_id: scoped_master_owner_id,
-            lock,
-          },
-        });
-      } catch (alert_err) {
-        warn_log("queue.run_overlap_alert_write_failed", {
-          run_started_at,
-          failure_bucket: isRevisionLimitExceededError(alert_err)
-            ? "revision_limit_exceeded"
-            : "write_error",
-          message: alert_err?.message || null,
-        });
-      }
-
-      return {
-        ok: true,
-        dry_run: false,
-        skipped: true,
-        reason: "queue_runner_lock_active",
-        run_started_at,
-        limit,
-        master_owner_id: scoped_master_owner_id,
-        lock,
-      };
+      return summary;
     },
-    fn: executeRun,
   });
 }
 

--- a/src/lib/providers/textgrid.js
+++ b/src/lib/providers/textgrid.js
@@ -1,6 +1,5 @@
 // ─── textgrid.js ──────────────────────────────────────────────────────────
 import crypto from "node:crypto";
-import axios from "axios";
 
 import ENV from "@/lib/config/env.js";
 import { recordSystemAlert } from "@/lib/domain/alerts/system-alerts.js";
@@ -16,9 +15,6 @@ const TEXTGRID_ACCOUNT_SID_PLACEHOLDER = "{ACCOUNT_SID}";
 const TEXTGRID_BASE_URL = `${TEXTGRID_API_ORIGIN}${TEXTGRID_API_VERSION_PATH}`;
 
 const REQUEST_TIMEOUT_MS = 15_000;
-const MAX_RETRIES = 4;
-const RETRY_BASE_DELAY_MS = 300;
-const RETRY_MAX_DELAY_MS = 10_000;
 // TextGrid send requests must use the fixed, Twilio-compatible REST path:
 //   POST /2010-04-01/Accounts/{AccountSid}/Messages.json
 const TEXTGRID_MESSAGES_RESOURCE = "/Messages.json";
@@ -35,16 +31,25 @@ const TEXTGRID_PROVIDER_CAPABILITIES = Object.freeze({
 // ══════════════════════════════════════════════════════════════════════════
 
 export class TextGridError extends Error {
-  constructor(message, { status, data } = {}) {
+  constructor(message, { status, data, raw_text, endpoint, to, from, body } = {}) {
     super(message);
     this.name = "TextGridError";
     this.status = status ?? null;
     this.data = data ?? null;
+    this.raw_text = raw_text ?? null;
+    this.endpoint = endpoint ?? null;
+    this.to = to ?? null;
+    this.from = from ?? null;
+    this.body = body ?? null;
   }
 }
 
 function clean(value) {
   return String(value ?? "").trim();
+}
+
+function lower(value) {
+  return clean(value).toLowerCase();
 }
 
 function safeEqual(left, right) {
@@ -218,13 +223,6 @@ export function verifyTextgridWebhookSignature({
   };
 }
 
-function toTextGridError(err) {
-  const status = err?.response?.status ?? null;
-  const data = err?.response?.data ?? null;
-  const message = data?.message ?? err?.message ?? "Unknown TextGrid error";
-  return new TextGridError(message, { status, data });
-}
-
 // ══════════════════════════════════════════════════════════════════════════
 // NORMALIZATION
 // ══════════════════════════════════════════════════════════════════════════
@@ -243,12 +241,8 @@ export function normalizeInboundTextgridPhone(value) {
 }
 
 // ══════════════════════════════════════════════════════════════════════════
-// RETRY ENGINE — Exponential Backoff + Full Jitter
+// RETRYABLE STATUS CLASSIFICATION
 // ══════════════════════════════════════════════════════════════════════════
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 const RETRYABLE_STATUSES = new Set([408, 409, 420, 425, 429, 500, 502, 503, 504]);
 
@@ -256,31 +250,12 @@ function isRetryable(status) {
   return RETRYABLE_STATUSES.has(status);
 }
 
-function calcBackoff(attempt) {
-  const exponential = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
-  const capped = Math.min(RETRY_MAX_DELAY_MS, exponential);
-  return Math.floor(Math.random() * capped);
-}
-
-async function requestWithRetry(config, attempt = 0) {
-  try {
-    return await axios({ timeout: REQUEST_TIMEOUT_MS, ...config });
-  } catch (err) {
-    const status = err?.response?.status ?? 0;
-    if (attempt < MAX_RETRIES && isRetryable(status)) {
-      await sleep(calcBackoff(attempt));
-      return requestWithRetry(config, attempt + 1);
-    }
-    throw err;
-  }
-}
-
 // ══════════════════════════════════════════════════════════════════════════
 // FAILURE BUCKET CLASSIFICATION
 // ══════════════════════════════════════════════════════════════════════════
 
 export function mapTextgridFailureBucket(result) {
-  if (!result || result.ok) return null;
+  if (!result || result.ok || result.success) return null;
 
   const status = result.error_status ?? 0;
   const msg = String(result.error_message ?? "").toLowerCase();
@@ -316,6 +291,11 @@ export async function sendTextgridSMS({
   const normalized_from = normalizePhone(from);
   const credentials = getTextgridSendCredentials();
 
+  console.log("TEXTGRID ENV:", {
+    sid: process.env.TEXTGRID_ACCOUNT_SID,
+    token_exists: !!process.env.TEXTGRID_AUTH_TOKEN,
+  });
+
   if (!normalized_to) {
     throw new TextGridError(`sendTextgridSMS: invalid 'to' number — "${to}"`);
   }
@@ -329,122 +309,164 @@ export async function sendTextgridSMS({
     throw new TextGridError("sendTextgridSMS: message body is empty");
   }
 
-  if (!credentials.configured) {
-    const missing_message =
-      `[TextGrid] Missing required env vars: ${credentials.missing.join(", ")}`;
-
-    const missing_endpoint = getTextgridSendEndpoint();
-
-    warn("textgrid.send_failed", {
-      to: normalized_to,
-      from: normalized_from,
-      status: null,
-      message: missing_message,
-      error_data: null,
-      endpoint: missing_endpoint,
-    });
-
-    await recordSystemAlert({
-      subsystem: "textgrid",
-      code: "send_failed",
-      severity: "high",
-      retryable: true,
-      summary: missing_message,
-      dedupe_key: "textgrid_send_missing_credentials",
-      affected_ids: [normalized_to, normalized_from],
-      metadata: {
-        missing: credentials.missing,
-      },
-    });
-
-    return {
-      ok: false,
-      provider: "textgrid",
-      message_id: null,
-      status: "failed",
-      error_message: missing_message,
-      error_status: null,
-      error_data: null,
-      to: normalized_to,
-      from: normalized_from,
-      body: trimmed_body,
-      endpoint: missing_endpoint,
-    };
-  }
-
-  const send_endpoint = getTextgridSendEndpoint(credentials.account_sid);
-  // TextGrid rejects the legacy extras we used to send here; only the core
-  // body/from/to JSON object is accepted on the Messages.json endpoint.
-  const payload = buildTextgridSendPayload({
-    body: trimmed_body,
-    from: normalized_from,
-    to: normalized_to,
-  });
-
   try {
-    const res = await requestWithRetry({
-      method: "post",
-      url: send_endpoint,
-      data: JSON.stringify(payload),
-      headers: buildTextgridSendHeaders(credentials),
+    if (!credentials.configured) {
+      throw new TextGridError(
+        `[TextGrid] Missing required env vars: ${credentials.missing.join(", ")}`,
+        {
+          endpoint: getTextgridSendEndpoint(),
+          to: normalized_to,
+          from: normalized_from,
+          body: trimmed_body,
+        }
+      );
+    }
+
+    const send_endpoint = getTextgridSendEndpoint(credentials.account_sid);
+    const payload = buildTextgridSendPayload({
+      body: trimmed_body,
+      from: normalized_from,
+      to: normalized_to,
     });
 
-    const data = res.data ?? {};
+    const response = await fetch(send_endpoint, {
+      method: "POST",
+      headers: buildTextgridSendHeaders(credentials),
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    }).catch((error) => {
+      throw new TextGridError(
+        clean(error?.message) || "TextGrid network request failed",
+        {
+          endpoint: send_endpoint,
+          to: normalized_to,
+          from: normalized_from,
+          body: trimmed_body,
+        }
+      );
+    });
+
+    const text = await response.text();
+
+    console.log("TEXTGRID STATUS:", response.status);
+    console.log("TEXTGRID RESPONSE:", text);
+
+    let data = null;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new TextGridError(`Invalid JSON response: ${text}`, {
+        status: response.status,
+        raw_text: text,
+        endpoint: send_endpoint,
+        to: normalized_to,
+        from: normalized_from,
+        body: trimmed_body,
+      });
+    }
+
+    if (!response.ok) {
+      throw new TextGridError(`TextGrid HTTP failure: ${text}`, {
+        status: response.status,
+        data,
+        raw_text: text,
+        endpoint: send_endpoint,
+        to: normalized_to,
+        from: normalized_from,
+        body: trimmed_body,
+      });
+    }
+
+    const sid = clean(data?.sid);
+    if (!sid) {
+      throw new TextGridError(`Missing SID (NOT SENT): ${text}`, {
+        status: response.status,
+        data,
+        raw_text: text,
+        endpoint: send_endpoint,
+        to: normalized_to,
+        from: normalized_from,
+        body: trimmed_body,
+      });
+    }
+
+    const provider_status = lower(data?.status);
+    if (["failed", "undelivered"].includes(provider_status)) {
+      throw new TextGridError(`Carrier rejected message: ${text}`, {
+        status: response.status,
+        data,
+        raw_text: text,
+        endpoint: send_endpoint,
+        to: normalized_to,
+        from: normalized_from,
+        body: trimmed_body,
+      });
+    }
 
     return {
+      success: true,
       ok: true,
       provider: "textgrid",
-      message_id: data.sid ?? data.id ?? data.message_id ?? data.message_sid ?? null,
-      status: data.status ?? "sent",
+      sid,
+      message_id: sid,
+      provider_message_id: sid,
+      status: clean(data?.status) || "sent",
       raw: data,
       to: normalized_to,
       from: normalized_from,
       body: trimmed_body,
       endpoint: send_endpoint,
     };
-  } catch (err) {
-    const tge = toTextGridError(err);
+  } catch (error) {
+    const tge =
+      error instanceof TextGridError
+        ? error
+        : new TextGridError(clean(error?.message) || "Unknown TextGrid error", {
+            endpoint: getTextgridSendEndpoint(credentials.account_sid || null),
+            to: normalized_to,
+            from: normalized_from,
+            body: trimmed_body,
+          });
 
     warn("textgrid.send_failed", {
       to_input: to,
       from_input: from,
-      to: normalized_to,
-      from: normalized_from,
+      to: tge.to || normalized_to,
+      from: tge.from || normalized_from,
       status: tge.status,
       message: tge.message,
       error_data: tge.data,
-      endpoint: send_endpoint,
+      raw_text: tge.raw_text,
+      endpoint: tge.endpoint || getTextgridSendEndpoint(credentials.account_sid || null),
       resource: TEXTGRID_MESSAGES_RESOURCE,
       client_reference_id,
     });
 
-    await recordSystemAlert({
-      subsystem: "textgrid",
-      code: "send_failed",
-      severity: tge.status && tge.status >= 500 ? "high" : "warning",
-      retryable: Boolean(tge.status ? isRetryable(tge.status) : true),
-      summary: `TextGrid send failed: ${tge.message}`,
-      dedupe_key: `textgrid_send_${clean(tge.status) || "unknown"}`,
-      affected_ids: [normalized_to, normalized_from],
-      metadata: {
-        status: tge.status,
-        data: tge.data,
-        endpoint: send_endpoint,
-      },
-    });
+    try {
+      await recordSystemAlert({
+        subsystem: "textgrid",
+        code: "send_failed",
+        severity: tge.status && tge.status >= 500 ? "high" : "warning",
+        retryable: Boolean(tge.status ? isRetryable(tge.status) : true),
+        summary: `TextGrid send failed: ${tge.message}`,
+        dedupe_key: `textgrid_send_${clean(tge.status) || "unknown"}`,
+        affected_ids: [tge.to || normalized_to, tge.from || normalized_from],
+        metadata: {
+          status: tge.status,
+          data: tge.data,
+          raw_text: tge.raw_text,
+          endpoint: tge.endpoint || getTextgridSendEndpoint(credentials.account_sid || null),
+        },
+      });
+    } catch (alert_error) {
+      warn("textgrid.send_failed_alert_record_failed", {
+        message: clean(alert_error?.message) || "unknown",
+        original_message: tge.message,
+        original_status: tge.status,
+        endpoint: tge.endpoint || getTextgridSendEndpoint(credentials.account_sid || null),
+      });
+    }
 
-    return {
-      ok: false,
-      provider: "textgrid",
-      message_id: null,
-      status: "failed",
-      error_message: tge.message,
-      error_status: tge.status,
-      error_data: tge.data,
-      to: normalized_to,
-      from: normalized_from,
-      body: trimmed_body,
-      endpoint: send_endpoint,
-    };
+    throw tge;
   }
 }

--- a/src/lib/sms/queue_message.js
+++ b/src/lib/sms/queue_message.js
@@ -8,6 +8,8 @@ import APP_IDS from "@/lib/config/app-ids.js";
 import { createItem, getFirstMatchingItem } from "@/lib/providers/podio.js";
 import { countSegments } from "@/lib/sms/personalize_template.js";
 import { info, warn } from "@/lib/logging/logger.js";
+import { hasSupabaseConfig } from "@/lib/supabase/client.js";
+import { insertSupabaseSendQueueRow } from "@/lib/supabase/sms-engine.js";
 
 // ══════════════════════════════════════════════════════════════════════════
 // QUEUE FIELD EXTERNAL IDS
@@ -106,6 +108,21 @@ function omitEmpty(value) {
   if (value === null || value === undefined) return undefined;
   if (typeof value === "string" && value.trim() === "") return undefined;
   return value;
+}
+
+function mapSendPriorityToNumber(value) {
+  const raw = String(value || "").trim().toLowerCase();
+  if (["_ urgent", "urgent", "high", "10"].includes(raw)) return 10;
+  if (["_ low", "low", "1"].includes(raw)) return 1;
+  return 5;
+}
+
+function shouldUseSupabaseQueueWrite() {
+  return (
+    hasSupabaseConfig() &&
+    runtimeDeps.createItem === defaultDeps.createItem &&
+    runtimeDeps.getFirstMatchingItem === defaultDeps.getFirstMatchingItem
+  );
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -303,6 +320,74 @@ export async function queueMessage(params = {}) {
     use_case: fields[QUEUE_FIELDS.use_case] || null,
     field_count: Object.keys(fields).length,
   });
+
+  if (shouldUseSupabaseQueueWrite()) {
+    const now = new Date().toISOString();
+    const queue_result = await insertSupabaseSendQueueRow({
+      queue_key: queue_id,
+      queue_id,
+      queue_status: "queued",
+      scheduled_for: params?.schedule?.scheduled_utc || params?.schedule?.scheduled_local || now,
+      scheduled_for_utc:
+        params?.schedule?.scheduled_utc || params?.schedule?.scheduled_local || now,
+      scheduled_for_local:
+        params?.schedule?.scheduled_local || params?.schedule?.scheduled_utc || now,
+      timezone: params?.schedule?.timezone || params?.context?.timezone || "America/Chicago",
+      contact_window: params?.context?.contact_window || null,
+      send_priority: mapSendPriorityToNumber(params?.context?.send_priority),
+      retry_count: 0,
+      max_retries: params?.context?.max_retries ?? 3,
+      message_body: params?.rendered_text || "",
+      message_text: params?.rendered_text || "",
+      to_phone_number: params?.context?.phone_e164 || null,
+      from_phone_number: params?.context?.from_phone_number || null,
+      property_address: params?.context?.property_address || null,
+      property_type: params?.context?.property_type || null,
+      owner_type: params?.context?.owner_type || null,
+      master_owner_id: params?.links?.master_owner_id || null,
+      prospect_id: params?.links?.prospect_id || null,
+      property_id: params?.links?.property_id || null,
+      market_id: params?.links?.market_id || null,
+      sms_agent_id: params?.links?.agent_id || null,
+      textgrid_number_id: params?.links?.textgrid_number_id || null,
+      template_id:
+        params?.resolution?.template_id ||
+        params?.resolution?.attachable_template_ref?.item_id ||
+        null,
+      touch_number: params?.context?.touch_number ?? null,
+      dnc_check: params?.context?.dnc_check || null,
+      current_stage: params?.resolution?.stage_code || null,
+      message_type: fields[QUEUE_FIELDS.message_type] || null,
+      use_case_template: params?.resolution?.use_case || null,
+      personalization_tags_used: params?.context?.placeholders_used || null,
+      character_count: String(params?.rendered_text || "").length,
+      metadata: {
+        source: "queue_message",
+        schedule: params?.schedule || null,
+        resolution_source: params?.resolution?.source || null,
+        queue_fields: fields,
+      },
+    });
+
+    info("queue_message.created", {
+      queue_id,
+      item_id: queue_result?.item_id || null,
+      storage: "supabase",
+      reason: queue_result?.reason || null,
+    });
+
+    return {
+      ok: queue_result?.ok !== false,
+      item_id: queue_result?.item_id || null,
+      queue_item_id: queue_result?.queue_item_id || null,
+      queue_id: queue_result?.queue_id || queue_id,
+      queue_key: queue_result?.queue_key || queue_id,
+      reason: queue_result?.reason || null,
+      storage: "supabase",
+      fields,
+      raw: queue_result?.raw || null,
+    };
+  }
 
   // Dedupe check: look for an existing row with the same queue ID
   try {

--- a/src/lib/sms/queue_message.js
+++ b/src/lib/sms/queue_message.js
@@ -335,6 +335,7 @@ export async function queueMessage(params = {}) {
       timezone: params?.schedule?.timezone || params?.context?.timezone || "America/Chicago",
       contact_window: params?.context?.contact_window || null,
       send_priority: mapSendPriorityToNumber(params?.context?.send_priority),
+      is_locked: false,
       retry_count: 0,
       max_retries: params?.context?.max_retries ?? 3,
       message_body: params?.rendered_text || "",

--- a/src/lib/supabase/client.js
+++ b/src/lib/supabase/client.js
@@ -1,0 +1,26 @@
+import { createClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL =
+  process.env.SUPABASE_URL || "https://placeholder.supabase.co";
+const SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || "placeholder-service-role-key";
+
+export function hasSupabaseConfig() {
+  return Boolean(
+    String(process.env.SUPABASE_URL || "").trim() &&
+      String(process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim()
+  );
+}
+
+export const supabase = createClient(
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  }
+);
+
+export default supabase;

--- a/src/lib/supabase/sms-engine.js
+++ b/src/lib/supabase/sms-engine.js
@@ -1,0 +1,1137 @@
+import crypto from "node:crypto";
+
+import {
+  mapTextgridFailureBucket,
+  normalizePhone,
+} from "@/lib/providers/textgrid.js";
+import { hasSupabaseConfig, supabase as defaultSupabase } from "@/lib/supabase/client.js";
+
+const SEND_QUEUE_TABLE = "send_queue";
+const MESSAGE_EVENTS_TABLE = "message_events";
+const TEXTGRID_NUMBERS_TABLE = "textgrid_numbers";
+const WEBHOOK_LOG_TABLE = "webhook_log";
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function lower(value) {
+  return clean(value).toLowerCase();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function addMinutesIso(value, minutes = 5) {
+  const base = new Date(value || nowIso());
+  base.setMinutes(base.getMinutes() + Number(minutes || 0));
+  return base.toISOString();
+}
+
+function asNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function asNullableNumber(value, fallback = null) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function ensureObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function pickFirst(...values) {
+  for (const value of values) {
+    if (value !== null && value !== undefined && clean(value) !== "") {
+      return value;
+    }
+  }
+  return null;
+}
+
+function toTimestamp(value) {
+  if (!value) return null;
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function normalizeQueueStatusValue(value) {
+  const raw = lower(value);
+  if (!raw) return "";
+  if (raw === "delivered") return "sent";
+  return raw;
+}
+
+function getSupabase(deps = {}) {
+  if (!deps.supabase && !deps.supabaseClient && !hasSupabaseConfig()) {
+    throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  }
+
+  return deps.supabase || deps.supabaseClient || defaultSupabase;
+}
+
+export function normalizeSendQueueRow(row) {
+  const safe_row = ensureObject(row);
+  const body = clean(safe_row.message_body || safe_row.message_text || "");
+
+  return {
+    id: safe_row.id,
+    queue_key: safe_row.queue_key || safe_row.queue_id,
+    queue_id: safe_row.queue_id || safe_row.queue_key,
+    queue_status: String(safe_row.queue_status || "").toLowerCase(),
+    scheduled_for:
+      safe_row.scheduled_for ||
+      safe_row.scheduled_for_utc ||
+      safe_row.scheduled_for_local ||
+      safe_row.created_at ||
+      null,
+    send_priority: Number(safe_row.send_priority ?? 5),
+    is_locked: Boolean(safe_row.is_locked),
+    locked_at: safe_row.locked_at || null,
+    lock_token: safe_row.lock_token || null,
+    retry_count: Number(safe_row.retry_count ?? 0),
+    max_retries: Number(safe_row.max_retries ?? 3),
+    next_retry_at: safe_row.next_retry_at || null,
+    message_body: body,
+    message_text: safe_row.message_text || safe_row.message_body || "",
+    to_phone_number: safe_row.to_phone_number || safe_row.to_number || null,
+    from_phone_number: safe_row.from_phone_number || safe_row.from_number || null,
+    provider_message_id: safe_row.provider_message_id || null,
+    master_owner_id: safe_row.master_owner_id || null,
+    prospect_id: safe_row.prospect_id || null,
+    property_id: safe_row.property_id || null,
+    market_id: safe_row.market_id || null,
+    sms_agent_id: safe_row.sms_agent_id || null,
+    textgrid_number_id: safe_row.textgrid_number_id || null,
+    template_id: safe_row.template_id || null,
+    property_address: safe_row.property_address || null,
+    property_type: safe_row.property_type || null,
+    owner_type: safe_row.owner_type || null,
+    timezone: safe_row.timezone || "America/Chicago",
+    contact_window: safe_row.contact_window || null,
+    touch_number: safe_row.touch_number || null,
+    dnc_check: safe_row.dnc_check || null,
+    current_stage: safe_row.current_stage || null,
+    message_type: safe_row.message_type || null,
+    use_case_template: safe_row.use_case_template || null,
+    personalization_tags_used: safe_row.personalization_tags_used || null,
+    character_count: Number(safe_row.character_count ?? body.length),
+    metadata: ensureObject(safe_row.metadata),
+    scheduled_for_local: safe_row.scheduled_for_local || null,
+    scheduled_for_utc: safe_row.scheduled_for_utc || null,
+    created_at: safe_row.created_at || null,
+    updated_at: safe_row.updated_at || null,
+    sent_at: safe_row.sent_at || null,
+    delivered_at: safe_row.delivered_at || null,
+    failed_reason: safe_row.failed_reason || null,
+    delivery_confirmed: safe_row.delivery_confirmed || null,
+  };
+}
+
+export function shouldRunSendQueueRow(row, now = nowIso()) {
+  const normalized = normalizeSendQueueRow(row);
+  const now_ts = toTimestamp(now) ?? Date.now();
+  const scheduled_ts = toTimestamp(normalized.scheduled_for);
+  const next_retry_ts = toTimestamp(normalized.next_retry_at);
+  const status = normalizeQueueStatusValue(normalized.queue_status);
+
+  if (status !== "queued") {
+    return {
+      ok: false,
+      reason: "queue_status_not_queued",
+      row: normalized,
+    };
+  }
+
+  if (normalized.is_locked || clean(normalized.lock_token)) {
+    return {
+      ok: false,
+      reason: "row_locked",
+      row: normalized,
+    };
+  }
+
+  if (scheduled_ts !== null && scheduled_ts > now_ts) {
+    return {
+      ok: false,
+      reason: "scheduled_for_in_future",
+      row: normalized,
+    };
+  }
+
+  if (next_retry_ts !== null && next_retry_ts > now_ts) {
+    return {
+      ok: false,
+      reason: "next_retry_pending",
+      row: normalized,
+    };
+  }
+
+  if (normalized.retry_count >= normalized.max_retries) {
+    return {
+      ok: false,
+      reason: "max_retries_reached",
+      row: normalized,
+    };
+  }
+
+  if (!clean(normalized.message_body)) {
+    return {
+      ok: false,
+      reason: "missing_message_body",
+      row: normalized,
+    };
+  }
+
+  if (!clean(normalized.to_phone_number)) {
+    return {
+      ok: false,
+      reason: "missing_to_phone_number",
+      row: normalized,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: "runnable",
+    row: normalized,
+  };
+}
+
+function getQueueSortValues(row) {
+  const normalized = normalizeSendQueueRow(row);
+  return {
+    priority: asNumber(normalized.send_priority, 5),
+    scheduled_ts: toTimestamp(normalized.scheduled_for) ?? Number.MIN_SAFE_INTEGER,
+  };
+}
+
+export function sortQueuedRows(rows = []) {
+  return [...rows].sort((left, right) => {
+    const left_values = getQueueSortValues(left);
+    const right_values = getQueueSortValues(right);
+
+    if (left_values.priority !== right_values.priority) {
+      return right_values.priority - left_values.priority;
+    }
+
+    return left_values.scheduled_ts - right_values.scheduled_ts;
+  });
+}
+
+export async function loadRunnableSendQueueRows(limit = 50, deps = {}) {
+  const supabase = getSupabase(deps);
+  const now = deps.now || nowIso();
+
+  const { data, error } = await supabase
+    .from(SEND_QUEUE_TABLE)
+    .select("*")
+    .in("queue_status", ["queued", "Queued"])
+    .order("send_priority", { ascending: false, nullsFirst: false })
+    .order("scheduled_for", { ascending: true, nullsFirst: true })
+    .order("scheduled_for_utc", { ascending: true, nullsFirst: true })
+    .limit(Math.max(limit * 4, 100));
+
+  if (error) throw error;
+
+  const raw_rows = Array.isArray(data) ? data : [];
+  const runnable = [];
+  const skipped = [];
+
+  for (const row of sortQueuedRows(raw_rows)) {
+    const decision = shouldRunSendQueueRow(row, now);
+    if (decision.ok) {
+      runnable.push(decision.row);
+    } else {
+      skipped.push({
+        id: decision.row?.id || null,
+        reason: decision.reason,
+      });
+    }
+  }
+
+  return {
+    rows: runnable.slice(0, limit),
+    raw_rows,
+    skipped,
+    now,
+  };
+}
+
+export async function claimSendQueueRow(row, deps = {}) {
+  const supabase = getSupabase(deps);
+  const normalized = normalizeSendQueueRow(row);
+  const claimed_at = deps.now || nowIso();
+  const lock_token = crypto.randomUUID();
+  const payload = {
+    queue_status: "sending",
+    is_locked: true,
+    locked_at: claimed_at,
+    lock_token,
+    updated_at: claimed_at,
+  };
+
+  if (typeof deps.claimSendQueueRow === "function") {
+    return deps.claimSendQueueRow(normalized, payload);
+  }
+
+  const query = supabase
+    .from(SEND_QUEUE_TABLE)
+    .update(payload)
+    .eq("id", normalized.id)
+    .in("queue_status", ["queued", "Queued"])
+    .is("lock_token", null)
+    .select()
+    .maybeSingle();
+
+  const { data, error } = await query;
+  if (error) throw error;
+  if (!data) {
+    return {
+      ok: false,
+      claimed: false,
+      reason: "queue_item_claim_conflict",
+      row: normalized,
+    };
+  }
+
+  return {
+    ok: true,
+    claimed: true,
+    reason: "claimed",
+    row: normalizeSendQueueRow(data),
+    lock_token,
+    claimed_at,
+  };
+}
+
+export async function updateSendQueueRowWithLock(row_id, lock_token, payload, deps = {}) {
+  const supabase = getSupabase(deps);
+
+  if (typeof deps.updateSendQueueRowWithLock === "function") {
+    return deps.updateSendQueueRowWithLock(row_id, lock_token, payload);
+  }
+
+  const { data, error } = await supabase
+    .from(SEND_QUEUE_TABLE)
+    .update(payload)
+    .eq("id", row_id)
+    .eq("lock_token", lock_token)
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+
+  return data ? normalizeSendQueueRow(data) : null;
+}
+
+function buildTimeFormatter(timezone = "America/Chicago") {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function buildDateParts(date, timezone = "America/Chicago") {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+
+  const hour = Number(parts.find((part) => part.type === "hour")?.value || 0);
+  const minute = Number(parts.find((part) => part.type === "minute")?.value || 0);
+
+  return {
+    hour,
+    minute,
+    minutes_of_day: hour * 60 + minute,
+  };
+}
+
+function parseWindowTime(raw = "", previous_period = null) {
+  const normalized = clean(raw).toUpperCase();
+  const match = normalized.match(/^(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?$/);
+  if (!match) return null;
+
+  let hour = Number(match[1]);
+  const minute = Number(match[2] || 0);
+  const period = match[3] || previous_period;
+
+  if (hour < 1 || hour > 12 || minute < 0 || minute > 59) {
+    return null;
+  }
+
+  if (!period) return null;
+
+  if (period === "AM") {
+    if (hour === 12) hour = 0;
+  } else if (period === "PM") {
+    if (hour !== 12) hour += 12;
+  } else {
+    return null;
+  }
+
+  return {
+    minutes_of_day: hour * 60 + minute,
+    period,
+  };
+}
+
+function parseContactWindow(window_text = "") {
+  const normalized = clean(window_text)
+    .replace(/\bLOCAL\b/gi, "")
+    .replace(/\bCT\b/gi, "")
+    .replace(/\bCST\b/gi, "")
+    .replace(/\bCDT\b/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!normalized) {
+    return {
+      valid: false,
+      reason: "missing_contact_window",
+    };
+  }
+
+  const parts = normalized
+    .split(/\s*-\s*|\s+to\s+/i)
+    .map((part) => clean(part))
+    .filter(Boolean);
+
+  if (parts.length !== 2) {
+    return {
+      valid: false,
+      reason: "invalid_contact_window_format",
+    };
+  }
+
+  const start = parseWindowTime(parts[0], null);
+  const end = parseWindowTime(parts[1], start?.period || null);
+
+  if (!start || !end) {
+    return {
+      valid: false,
+      reason: "invalid_contact_window_time",
+    };
+  }
+
+  return {
+    valid: true,
+    start_minutes: start.minutes_of_day,
+    end_minutes: end.minutes_of_day,
+  };
+}
+
+export function evaluateContactWindow(row, deps = {}) {
+  const normalized = normalizeSendQueueRow(row);
+  const timezone = clean(normalized.timezone) || "America/Chicago";
+  const current_time = deps.now ? new Date(deps.now) : new Date();
+  let resolved_timezone = timezone;
+
+  try {
+    buildTimeFormatter(timezone).format(current_time);
+  } catch {
+    resolved_timezone = "America/Chicago";
+  }
+
+  if (!clean(normalized.contact_window)) {
+    return {
+      allowed: true,
+      reason: "no_contact_window",
+      timezone: resolved_timezone,
+      valid_window: false,
+    };
+  }
+
+  const parsed_window = parseContactWindow(normalized.contact_window);
+  if (!parsed_window.valid) {
+    return {
+      allowed: true,
+      reason: parsed_window.reason,
+      timezone: resolved_timezone,
+      valid_window: false,
+    };
+  }
+
+  const now_parts = buildDateParts(current_time, resolved_timezone);
+  const current_minutes = now_parts.minutes_of_day;
+  const start_minutes = parsed_window.start_minutes;
+  const end_minutes = parsed_window.end_minutes;
+
+  let within_window = false;
+  if (start_minutes <= end_minutes) {
+    within_window = current_minutes >= start_minutes && current_minutes <= end_minutes;
+  } else {
+    within_window = current_minutes >= start_minutes || current_minutes <= end_minutes;
+  }
+
+  return {
+    allowed: within_window,
+    reason: within_window ? "inside_contact_window" : "outside_contact_window",
+    timezone: resolved_timezone,
+    valid_window: true,
+    current_minutes,
+    start_minutes,
+    end_minutes,
+  };
+}
+
+export async function selectAvailableTextgridNumber(row, deps = {}) {
+  const supabase = getSupabase(deps);
+  const normalized = normalizeSendQueueRow(row);
+
+  if (clean(normalized.from_phone_number)) {
+    return {
+      ok: true,
+      selected: {
+        id: normalized.textgrid_number_id || null,
+        phone_number: normalizePhone(normalized.from_phone_number),
+        metadata: {},
+      },
+      from_phone_number: normalizePhone(normalized.from_phone_number),
+      reason: "queue_row_from_phone_number_present",
+    };
+  }
+
+  if (typeof deps.selectAvailableTextgridNumber === "function") {
+    return deps.selectAvailableTextgridNumber(normalized);
+  }
+
+  const { data, error } = await supabase
+    .from(TEXTGRID_NUMBERS_TABLE)
+    .select("*")
+    .order("messages_sent_today", { ascending: true, nullsFirst: true })
+    .order("last_used_at", { ascending: true, nullsFirst: true })
+    .limit(50);
+
+  if (error) throw error;
+
+  const rows = Array.isArray(data) ? data : [];
+  const active_rows = rows.filter((candidate) => {
+    const status = lower(candidate?.status);
+    const daily_limit = asNullableNumber(candidate?.daily_limit, null);
+    const sent_today = asNumber(candidate?.messages_sent_today, 0);
+
+    if (status && status !== "active") return false;
+    if (daily_limit !== null && sent_today >= daily_limit) return false;
+    return Boolean(normalizePhone(candidate?.phone_number));
+  });
+
+  const preferred = active_rows.find(
+    (candidate) =>
+      String(candidate?.id || "") === String(normalized.textgrid_number_id || "")
+  );
+  const selected = preferred || active_rows[0] || null;
+
+  if (!selected) {
+    return {
+      ok: false,
+      reason: "no_available_textgrid_numbers",
+      selected: null,
+      from_phone_number: null,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: preferred ? "preferred_textgrid_number_selected" : "rotation_textgrid_number_selected",
+    selected,
+    from_phone_number: normalizePhone(selected.phone_number),
+  };
+}
+
+export async function reserveFromPhoneNumber(row, lock_token, selection, deps = {}) {
+  const normalized = normalizeSendQueueRow(row);
+  const from_phone_number = normalizePhone(selection?.from_phone_number);
+  const textgrid_number_id = selection?.selected?.id || null;
+  const now = deps.now || nowIso();
+
+  if (!from_phone_number) {
+    throw new Error("missing_from_phone_number");
+  }
+
+  const updated = await updateSendQueueRowWithLock(
+    normalized.id,
+    lock_token,
+    {
+      from_phone_number,
+      textgrid_number_id,
+      updated_at: now,
+    },
+    deps
+  );
+
+  return updated || {
+    ...normalized,
+    from_phone_number,
+    textgrid_number_id,
+  };
+}
+
+export async function incrementTextgridNumberUsage(selection, deps = {}) {
+  const supabase = getSupabase(deps);
+  const selected = selection?.selected || null;
+
+  if (!selected?.id) return null;
+
+  if (typeof deps.incrementTextgridNumberUsage === "function") {
+    return deps.incrementTextgridNumberUsage(selected);
+  }
+
+  const next_sent_today = asNumber(selected.messages_sent_today, 0) + 1;
+  const payload = {
+    messages_sent_today: next_sent_today,
+    last_used_at: deps.now || nowIso(),
+    updated_at: deps.now || nowIso(),
+  };
+
+  const { data, error } = await supabase
+    .from(TEXTGRID_NUMBERS_TABLE)
+    .update(payload)
+    .eq("id", selected.id)
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+  return data || null;
+}
+
+function buildSuccessMessageEvent(row, send_result, options = {}) {
+  const normalized = normalizeSendQueueRow(row);
+  const event_timestamp = options.now || nowIso();
+  const queue_key = clean(normalized.queue_key) || clean(normalized.queue_id) || String(normalized.id);
+  const sid = clean(
+    options.provider_message_sid ||
+      send_result?.sid ||
+      send_result?.provider_message_id ||
+      send_result?.message_id
+  );
+
+  return {
+    message_event_key: `outbound_${queue_key}`,
+    provider_message_sid: sid,
+    direction: "outbound",
+    event_type: "outbound_send",
+    message_body: normalized.message_body,
+    to_phone_number: normalized.to_phone_number,
+    from_phone_number: normalized.from_phone_number,
+    queue_id: normalized.id,
+    sent_at: event_timestamp,
+    event_timestamp,
+    created_at: event_timestamp,
+    provider_delivery_status: clean(send_result?.status) || null,
+    delivery_status: "sent",
+    character_count: normalized.character_count || normalized.message_body.length,
+    latency_ms: options.latency_ms ?? null,
+    master_owner_id: normalized.master_owner_id,
+    prospect_id: normalized.prospect_id,
+    property_id: normalized.property_id,
+    market_id: normalized.market_id,
+    sms_agent_id: normalized.sms_agent_id,
+    textgrid_number_id: normalized.textgrid_number_id,
+    template_id: normalized.template_id,
+    property_address: normalized.property_address,
+    stage_before: normalized.current_stage || null,
+    stage_after: normalized.current_stage || null,
+    metadata: {
+      source: "supabase_send_queue",
+      queue_key,
+      send_result,
+      queue_row: {
+        id: normalized.id,
+        queue_key: normalized.queue_key,
+        queue_status: normalized.queue_status,
+      },
+    },
+  };
+}
+
+function buildFailureMessageEvent(row, error, options = {}) {
+  const normalized = normalizeSendQueueRow(row);
+  const event_timestamp = options.now || nowIso();
+  const queue_key = clean(normalized.queue_key) || clean(normalized.queue_id) || String(normalized.id);
+  const timestamp_key = event_timestamp.replace(/[^0-9]/g, "").slice(0, 14);
+  const failure_result =
+    ensureObject(options.send_result).error_message || ensureObject(options.send_result).error_status
+      ? options.send_result
+      : {
+          ok: false,
+          error_message: clean(error?.message),
+          error_status: error?.status || null,
+        };
+
+  return {
+    message_event_key: `failed_${queue_key}_${timestamp_key}`,
+    direction: "outbound",
+    event_type: "outbound_send_failed",
+    message_body: normalized.message_body,
+    to_phone_number: normalized.to_phone_number,
+    from_phone_number: normalized.from_phone_number,
+    queue_id: normalized.id,
+    failed_at: event_timestamp,
+    event_timestamp,
+    error_message: clean(error?.message) || clean(options.send_result?.error_message) || "send_failed",
+    failure_reason: clean(error?.message) || clean(options.send_result?.error_message) || "send_failed",
+    failure_bucket: mapTextgridFailureBucket(failure_result) || null,
+    is_final_failure:
+      normalized.retry_count + 1 >= normalized.max_retries,
+    master_owner_id: normalized.master_owner_id,
+    prospect_id: normalized.prospect_id,
+    property_id: normalized.property_id,
+    market_id: normalized.market_id,
+    sms_agent_id: normalized.sms_agent_id,
+    textgrid_number_id: normalized.textgrid_number_id,
+    template_id: normalized.template_id,
+    property_address: normalized.property_address,
+    metadata: {
+      source: "supabase_send_queue",
+      queue_key,
+      error: {
+        message: clean(error?.message) || null,
+        status: error?.status || null,
+      },
+      send_result: options.send_result || null,
+    },
+  };
+}
+
+export async function writeOutboundSuccessMessageEvent(row, send_result, options = {}) {
+  const payload = buildSuccessMessageEvent(row, send_result, options);
+
+  if (typeof options.writeOutboundSuccessMessageEvent === "function") {
+    return options.writeOutboundSuccessMessageEvent(payload);
+  }
+
+  const supabase = getSupabase(options);
+
+  const { data, error } = await supabase
+    .from(MESSAGE_EVENTS_TABLE)
+    .upsert(payload, {
+      onConflict: "message_event_key",
+      ignoreDuplicates: false,
+    })
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+  return data || payload;
+}
+
+export async function writeOutboundFailureMessageEvent(row, error, options = {}) {
+  const payload = buildFailureMessageEvent(row, error, options);
+
+  if (typeof options.writeOutboundFailureMessageEvent === "function") {
+    return options.writeOutboundFailureMessageEvent(payload);
+  }
+
+  const supabase = getSupabase(options);
+
+  const { data, error: insert_error } = await supabase
+    .from(MESSAGE_EVENTS_TABLE)
+    .insert(payload)
+    .select()
+    .maybeSingle();
+
+  if (insert_error) throw insert_error;
+  return data || payload;
+}
+
+export async function finalizeSendQueueSuccess(row, lock_token, send_result, options = {}) {
+  const normalized = normalizeSendQueueRow(row);
+  const provider_message_id = clean(
+    send_result?.sid || send_result?.provider_message_id || send_result?.message_id
+  );
+
+  if (!provider_message_id) {
+    throw new Error("SEND FAILED - NO SID");
+  }
+
+  const now = options.now || nowIso();
+  const payload = {
+    queue_status: "sent",
+    sent_at: now,
+    delivery_confirmed: "pending",
+    provider_message_id,
+    is_locked: false,
+    locked_at: null,
+    lock_token: null,
+    character_count: normalized.message_body.length,
+    updated_at: now,
+    failed_reason: null,
+    from_phone_number: normalized.from_phone_number,
+    textgrid_number_id: normalized.textgrid_number_id,
+  };
+
+  const updated_row = await updateSendQueueRowWithLock(
+    normalized.id,
+    lock_token,
+    payload,
+    options
+  );
+
+  if (!updated_row) {
+    throw new Error("queue_row_lock_mismatch_after_send");
+  }
+
+  return updated_row;
+}
+
+export async function finalizeSendQueueFailure(row, lock_token, error, options = {}) {
+  const normalized = normalizeSendQueueRow(row);
+  const now = options.now || nowIso();
+  const next_retry_count = normalized.retry_count + 1;
+  const is_final_failure = next_retry_count >= normalized.max_retries;
+
+  const payload = {
+    queue_status: is_final_failure ? "failed" : "queued",
+    failed_reason: clean(error?.message) || "send_failed",
+    retry_count: next_retry_count,
+    next_retry_at: is_final_failure ? null : addMinutesIso(now, 5),
+    is_locked: false,
+    locked_at: null,
+    lock_token: null,
+    updated_at: now,
+  };
+
+  const updated_row = await updateSendQueueRowWithLock(
+    normalized.id,
+    lock_token,
+    payload,
+    options
+  );
+
+  return updated_row || {
+    ...normalized,
+    ...payload,
+  };
+}
+
+export async function releaseSkippedQueueRow(row, lock_token, reason, options = {}) {
+  const normalized = normalizeSendQueueRow(row);
+  const now = options.now || nowIso();
+
+  const payload = {
+    queue_status: "queued",
+    is_locked: false,
+    locked_at: null,
+    lock_token: null,
+    updated_at: now,
+  };
+
+  const updated_row = await updateSendQueueRowWithLock(
+    normalized.id,
+    lock_token,
+    payload,
+    options
+  );
+
+  return updated_row || {
+    ...normalized,
+    ...payload,
+    skip_reason: reason,
+  };
+}
+
+function buildWebhookLogCandidates({
+  event_type,
+  direction = null,
+  provider_message_sid = null,
+  payload = {},
+  headers = {},
+  received_at = nowIso(),
+  source = "textgrid",
+} = {}) {
+  const raw_payload = ensureObject(payload);
+  const raw_headers = ensureObject(headers);
+
+  return [
+    {
+      provider: source,
+      event_type,
+      direction,
+      provider_message_sid,
+      payload: raw_payload,
+      headers: raw_headers,
+      created_at: received_at,
+    },
+    {
+      source,
+      event_type,
+      direction,
+      provider_message_sid,
+      raw_payload,
+      headers: raw_headers,
+      created_at: received_at,
+    },
+    {
+      event_type,
+      provider_message_sid,
+      payload: raw_payload,
+      created_at: received_at,
+    },
+    {
+      raw_payload,
+      created_at: received_at,
+    },
+  ];
+}
+
+export async function writeWebhookLog(options = {}) {
+  const candidates = buildWebhookLogCandidates(options);
+
+  if (typeof options.writeWebhookLog === "function") {
+    return options.writeWebhookLog(candidates[0]);
+  }
+
+  const supabase = getSupabase(options);
+
+  let last_error = null;
+  for (const payload of candidates) {
+    const { data, error } = await supabase
+      .from(WEBHOOK_LOG_TABLE)
+      .insert(payload)
+      .select()
+      .maybeSingle();
+
+    if (!error) return data || payload;
+    last_error = error;
+  }
+
+  throw last_error || new Error("webhook_log_write_failed");
+}
+
+export async function logInboundMessageEvent(payload, options = {}) {
+  const now = options.now || nowIso();
+  const message_sid = clean(
+    payload?.message_id || payload?.provider_message_sid || payload?.sid
+  );
+  const from_phone_number = normalizePhone(payload?.from || payload?.from_phone_number);
+  const to_phone_number = normalizePhone(payload?.to || payload?.to_phone_number);
+  const message_body = clean(payload?.body || payload?.message_body);
+
+  const event = {
+    message_event_key: `inbound_${message_sid || crypto.randomUUID()}`,
+    provider_message_sid: message_sid || null,
+    direction: "inbound",
+    event_type: "inbound_sms",
+    message_body,
+    to_phone_number,
+    from_phone_number,
+    received_at: pickFirst(payload?.received_at, now),
+    event_timestamp: pickFirst(payload?.received_at, now),
+    created_at: now,
+    character_count: message_body.length,
+    metadata: {
+      source: "textgrid_inbound_webhook",
+      payload,
+    },
+  };
+
+  if (typeof options.logInboundMessageEvent === "function") {
+    return options.logInboundMessageEvent(event);
+  }
+
+  const supabase = getSupabase(options);
+
+  const { data, error } = await supabase
+    .from(MESSAGE_EVENTS_TABLE)
+    .upsert(event, {
+      onConflict: "message_event_key",
+      ignoreDuplicates: false,
+    })
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+  return data || event;
+}
+
+export async function syncDeliveryEvent(payload, options = {}) {
+  const now = options.now || nowIso();
+  const provider_message_sid = clean(payload?.message_id || payload?.provider_message_sid || payload?.sid);
+  const provider_status = lower(payload?.status || payload?.provider_delivery_status);
+  const raw_carrier_status = clean(payload?.error_status || payload?.status || "");
+  const delivery_status =
+    provider_status === "delivered"
+      ? "delivered"
+      : ["failed", "undelivered", "error"].includes(provider_status)
+        ? "failed"
+        : provider_status || "sent";
+
+  const message_events_payload = {
+    provider_delivery_status: provider_status || null,
+    raw_carrier_status: raw_carrier_status || null,
+    delivery_status,
+  };
+
+  if (provider_status === "delivered") {
+    message_events_payload.delivered_at = pickFirst(payload?.delivered_at, now);
+  } else if (["failed", "undelivered", "error"].includes(provider_status)) {
+    message_events_payload.failed_at = now;
+    message_events_payload.error_message =
+      clean(payload?.error_message) || "delivery_failed";
+    message_events_payload.failure_reason =
+      clean(payload?.error_message) || "delivery_failed";
+    message_events_payload.failure_bucket =
+      mapTextgridFailureBucket({
+        ok: false,
+        error_message: payload?.error_message,
+        error_status: payload?.error_status,
+      }) || null;
+  }
+
+  if (typeof options.syncDeliveryEvent === "function") {
+    return options.syncDeliveryEvent(provider_message_sid, message_events_payload);
+  }
+
+  const supabase = getSupabase(options);
+
+  const { data: message_events_data, error: message_events_error } = await supabase
+    .from(MESSAGE_EVENTS_TABLE)
+    .update(message_events_payload)
+    .eq("provider_message_sid", provider_message_sid)
+    .select();
+
+  if (message_events_error) throw message_events_error;
+
+  const queue_payload = {
+    updated_at: now,
+  };
+
+  if (provider_status === "delivered") {
+    queue_payload.delivered_at = pickFirst(payload?.delivered_at, now);
+    queue_payload.delivery_confirmed = "confirmed";
+  } else if (["failed", "undelivered", "error"].includes(provider_status)) {
+    queue_payload.delivery_confirmed = "failed";
+    queue_payload.failed_reason =
+      clean(payload?.error_message) || "delivery_failed";
+  }
+
+  const { data: send_queue_data, error: send_queue_error } = await supabase
+    .from(SEND_QUEUE_TABLE)
+    .update(queue_payload)
+    .eq("provider_message_id", provider_message_sid)
+    .select();
+
+  if (send_queue_error) throw send_queue_error;
+
+  return {
+    provider_message_sid,
+    provider_status,
+    message_events_count: Array.isArray(message_events_data) ? message_events_data.length : 0,
+    send_queue_count: Array.isArray(send_queue_data) ? send_queue_data.length : 0,
+  };
+}
+
+export async function insertSupabaseSendQueueRow(payload, deps = {}) {
+  const now = deps.now || nowIso();
+  const row = normalizeSendQueueRow({
+    ...payload,
+    queue_status: payload.queue_status || "queued",
+    scheduled_for: payload.scheduled_for || payload.scheduled_for_utc || now,
+    scheduled_for_utc: payload.scheduled_for_utc || payload.scheduled_for || now,
+    scheduled_for_local: payload.scheduled_for_local || payload.scheduled_for || now,
+    created_at: payload.created_at || now,
+    updated_at: payload.updated_at || now,
+  });
+
+  const insert_payload = {
+    queue_key: clean(row.queue_key) || crypto.randomUUID(),
+    queue_id: clean(row.queue_id) || clean(row.queue_key) || crypto.randomUUID(),
+    queue_status: normalizeQueueStatusValue(row.queue_status) || "queued",
+    scheduled_for: row.scheduled_for || now,
+    send_priority: asNumber(row.send_priority, 5),
+    is_locked: false,
+    locked_at: null,
+    lock_token: null,
+    retry_count: asNumber(row.retry_count, 0),
+    max_retries: asNumber(row.max_retries, 3),
+    next_retry_at: row.next_retry_at || null,
+    message_body: row.message_body,
+    message_text: row.message_text || row.message_body,
+    to_phone_number: normalizePhone(row.to_phone_number),
+    from_phone_number: normalizePhone(row.from_phone_number) || null,
+    metadata: row.metadata,
+    created_at: row.created_at || now,
+    updated_at: row.updated_at || now,
+    property_address: row.property_address || null,
+    queue_sequence: row.touch_number || null,
+    property_type: row.property_type || null,
+    owner_type: row.owner_type || null,
+    scheduled_for_local: row.scheduled_for_local || row.scheduled_for || now,
+    scheduled_for_utc: row.scheduled_for_utc || row.scheduled_for || now,
+    timezone: row.timezone || "America/Chicago",
+    contact_window: row.contact_window || null,
+    sent_at: row.sent_at || null,
+    delivered_at: row.delivered_at || null,
+    failed_reason: row.failed_reason || null,
+    delivery_confirmed: row.delivery_confirmed || null,
+    master_owner_id: row.master_owner_id || null,
+    prospect_id: row.prospect_id || null,
+    property_id: row.property_id || null,
+    market_id: row.market_id || null,
+    sms_agent_id: row.sms_agent_id || null,
+    textgrid_number_id: row.textgrid_number_id || null,
+    template_id: row.template_id || null,
+    touch_number: row.touch_number || null,
+    dnc_check: row.dnc_check || null,
+    current_stage: row.current_stage || null,
+    message_type: row.message_type || null,
+    use_case_template: row.use_case_template || null,
+    personalization_tags_used: row.personalization_tags_used || null,
+    character_count: row.character_count || row.message_body.length,
+    provider_message_id: row.provider_message_id || null,
+  };
+
+  if (typeof deps.insertSupabaseSendQueueRow === "function") {
+    return deps.insertSupabaseSendQueueRow(insert_payload);
+  }
+
+  const supabase = getSupabase(deps);
+
+  const { data, error } = await supabase
+    .from(SEND_QUEUE_TABLE)
+    .insert(insert_payload)
+    .select()
+    .maybeSingle();
+
+  if (!error) {
+    return {
+      ok: true,
+      item_id: data?.id || null,
+      queue_item_id: data?.id || null,
+      queue_id: data?.queue_id || insert_payload.queue_id,
+      queue_key: data?.queue_key || insert_payload.queue_key,
+      raw: data || insert_payload,
+    };
+  }
+
+  if (error.code === "23505") {
+    const { data: existing, error: existing_error } = await supabase
+      .from(SEND_QUEUE_TABLE)
+      .select("*")
+      .eq("queue_key", insert_payload.queue_key)
+      .maybeSingle();
+
+    if (existing_error) throw existing_error;
+
+    return {
+      ok: false,
+      reason: "duplicate_blocked",
+      item_id: existing?.id || null,
+      queue_item_id: existing?.id || null,
+      queue_id: existing?.queue_id || insert_payload.queue_id,
+      queue_key: existing?.queue_key || insert_payload.queue_key,
+      raw: existing || insert_payload,
+    };
+  }
+
+  throw error;
+}

--- a/src/lib/supabase/sms-engine.js
+++ b/src/lib/supabase/sms-engine.js
@@ -39,6 +39,24 @@ function asNullableNumber(value, fallback = null) {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+export function normalizeQueueRowId(value, fallback = null) {
+  if (value === null || value === undefined) return fallback;
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? Math.trunc(value) : fallback;
+  }
+
+  const normalized = clean(value);
+  if (!normalized) return fallback;
+
+  if (/^\d+$/.test(normalized)) {
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : fallback;
+  }
+
+  return normalized;
+}
+
 function ensureObject(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : {};
 }
@@ -75,10 +93,20 @@ function getSupabase(deps = {}) {
 
 export function normalizeSendQueueRow(row) {
   const safe_row = ensureObject(row);
+  const row_id = normalizeQueueRowId(
+    safe_row.id ??
+      safe_row.queue_row_id ??
+      safe_row.queue_item_id ??
+      safe_row.item_id,
+    null
+  );
   const body = clean(safe_row.message_body || safe_row.message_text || "");
 
   return {
-    id: safe_row.id,
+    id: row_id,
+    queue_row_id: row_id,
+    queue_item_id: row_id,
+    item_id: row_id,
     queue_key: safe_row.queue_key || safe_row.queue_id,
     queue_id: safe_row.queue_id || safe_row.queue_key,
     queue_status: String(safe_row.queue_status || "").toLowerCase(),
@@ -263,8 +291,15 @@ export async function loadRunnableSendQueueRows(limit = 50, deps = {}) {
 }
 
 export async function claimSendQueueRow(row, deps = {}) {
-  const supabase = getSupabase(deps);
   const normalized = normalizeSendQueueRow(row);
+  if (!normalized.id) {
+    return {
+      ok: false,
+      claimed: false,
+      reason: "missing_queue_row_id",
+      row: normalized,
+    };
+  }
   const claimed_at = deps.now || nowIso();
   const lock_token = crypto.randomUUID();
   const payload = {
@@ -278,6 +313,8 @@ export async function claimSendQueueRow(row, deps = {}) {
   if (typeof deps.claimSendQueueRow === "function") {
     return deps.claimSendQueueRow(normalized, payload);
   }
+
+  const supabase = getSupabase(deps);
 
   const query = supabase
     .from(SEND_QUEUE_TABLE)
@@ -310,16 +347,22 @@ export async function claimSendQueueRow(row, deps = {}) {
 }
 
 export async function updateSendQueueRowWithLock(row_id, lock_token, payload, deps = {}) {
-  const supabase = getSupabase(deps);
+  const normalized_row_id = normalizeQueueRowId(row_id, null);
+
+  if (!normalized_row_id) {
+    throw new Error("missing_queue_row_id");
+  }
 
   if (typeof deps.updateSendQueueRowWithLock === "function") {
-    return deps.updateSendQueueRowWithLock(row_id, lock_token, payload);
+    return deps.updateSendQueueRowWithLock(normalized_row_id, lock_token, payload);
   }
+
+  const supabase = getSupabase(deps);
 
   const { data, error } = await supabase
     .from(SEND_QUEUE_TABLE)
     .update(payload)
-    .eq("id", row_id)
+    .eq("id", normalized_row_id)
     .eq("lock_token", lock_token)
     .select()
     .maybeSingle();
@@ -485,7 +528,6 @@ export function evaluateContactWindow(row, deps = {}) {
 }
 
 export async function selectAvailableTextgridNumber(row, deps = {}) {
-  const supabase = getSupabase(deps);
   const normalized = normalizeSendQueueRow(row);
 
   if (clean(normalized.from_phone_number)) {
@@ -504,6 +546,8 @@ export async function selectAvailableTextgridNumber(row, deps = {}) {
   if (typeof deps.selectAvailableTextgridNumber === "function") {
     return deps.selectAvailableTextgridNumber(normalized);
   }
+
+  const supabase = getSupabase(deps);
 
   const { data, error } = await supabase
     .from(TEXTGRID_NUMBERS_TABLE)
@@ -577,7 +621,6 @@ export async function reserveFromPhoneNumber(row, lock_token, selection, deps = 
 }
 
 export async function incrementTextgridNumberUsage(selection, deps = {}) {
-  const supabase = getSupabase(deps);
   const selected = selection?.selected || null;
 
   if (!selected?.id) return null;
@@ -585,6 +628,8 @@ export async function incrementTextgridNumberUsage(selection, deps = {}) {
   if (typeof deps.incrementTextgridNumberUsage === "function") {
     return deps.incrementTextgridNumberUsage(selected);
   }
+
+  const supabase = getSupabase(deps);
 
   const next_sent_today = asNumber(selected.messages_sent_today, 0) + 1;
   const payload = {
@@ -1107,6 +1152,7 @@ export async function insertSupabaseSendQueueRow(payload, deps = {}) {
     return {
       ok: true,
       item_id: data?.id || null,
+      queue_row_id: data?.id || null,
       queue_item_id: data?.id || null,
       queue_id: data?.queue_id || insert_payload.queue_id,
       queue_key: data?.queue_key || insert_payload.queue_key,
@@ -1127,6 +1173,7 @@ export async function insertSupabaseSendQueueRow(payload, deps = {}) {
       ok: false,
       reason: "duplicate_blocked",
       item_id: existing?.id || null,
+      queue_row_id: existing?.id || null,
       queue_item_id: existing?.id || null,
       queue_id: existing?.queue_id || insert_payload.queue_id,
       queue_key: existing?.queue_key || insert_payload.queue_key,

--- a/src/lib/supabase/sms-engine.js
+++ b/src/lib/supabase/sms-engine.js
@@ -97,8 +97,8 @@ export function normalizeSendQueueRow(row) {
     next_retry_at: safe_row.next_retry_at || null,
     message_body: body,
     message_text: safe_row.message_text || safe_row.message_body || "",
-    to_phone_number: safe_row.to_phone_number || safe_row.to_number || null,
-    from_phone_number: safe_row.from_phone_number || safe_row.from_number || null,
+    to_phone_number: safe_row.to_phone_number || null,
+    from_phone_number: safe_row.from_phone_number || null,
     provider_message_id: safe_row.provider_message_id || null,
     master_owner_id: safe_row.master_owner_id || null,
     prospect_id: safe_row.prospect_id || null,
@@ -136,9 +136,9 @@ export function shouldRunSendQueueRow(row, now = nowIso()) {
   const now_ts = toTimestamp(now) ?? Date.now();
   const scheduled_ts = toTimestamp(normalized.scheduled_for);
   const next_retry_ts = toTimestamp(normalized.next_retry_at);
-  const status = normalizeQueueStatusValue(normalized.queue_status);
+  const queue_status_value = normalizeQueueStatusValue(normalized.queue_status);
 
-  if (status !== "queued") {
+  if (queue_status_value !== "queued") {
     return {
       ok: false,
       reason: "queue_status_not_queued",
@@ -204,7 +204,7 @@ export function shouldRunSendQueueRow(row, now = nowIso()) {
 function getQueueSortValues(row) {
   const normalized = normalizeSendQueueRow(row);
   return {
-    priority: asNumber(normalized.send_priority, 5),
+    send_priority_value: asNumber(normalized.send_priority, 5),
     scheduled_ts: toTimestamp(normalized.scheduled_for) ?? Number.MIN_SAFE_INTEGER,
   };
 }
@@ -214,8 +214,8 @@ export function sortQueuedRows(rows = []) {
     const left_values = getQueueSortValues(left);
     const right_values = getQueueSortValues(right);
 
-    if (left_values.priority !== right_values.priority) {
-      return right_values.priority - left_values.priority;
+    if (left_values.send_priority_value !== right_values.send_priority_value) {
+      return right_values.send_priority_value - left_values.send_priority_value;
     }
 
     return left_values.scheduled_ts - right_values.scheduled_ts;
@@ -229,10 +229,11 @@ export async function loadRunnableSendQueueRows(limit = 50, deps = {}) {
   const { data, error } = await supabase
     .from(SEND_QUEUE_TABLE)
     .select("*")
-    .in("queue_status", ["queued", "Queued"])
+    .eq("queue_status", "queued")
+    .or(`scheduled_for.is.null,scheduled_for.lte.${now}`)
+    .not("is_locked", "is", "true")
     .order("send_priority", { ascending: false, nullsFirst: false })
     .order("scheduled_for", { ascending: true, nullsFirst: true })
-    .order("scheduled_for_utc", { ascending: true, nullsFirst: true })
     .limit(Math.max(limit * 4, 100));
 
   if (error) throw error;

--- a/src/lib/verification/live-textgrid.js
+++ b/src/lib/verification/live-textgrid.js
@@ -60,18 +60,43 @@ export async function runLiveTextgridSendVerification({
     };
   }
 
-  const send_result = await sendTextgridSMS({
-    to,
-    from,
-    body: message_body,
-    client_reference_id,
-    message_type: "sms",
-  });
-
-  if (!send_result.ok) {
+  let send_result;
+  try {
+    send_result = await sendTextgridSMS({
+      to,
+      from,
+      body: message_body,
+      client_reference_id,
+      message_type: "sms",
+    });
+  } catch (error) {
     return {
       ok: false,
-      reason: send_result.error_message || "textgrid_send_failed",
+      reason: clean(error?.message) || "textgrid_send_failed",
+      run_id,
+      client_reference_id,
+      send_result: {
+        success: false,
+        ok: false,
+        sid: null,
+        message_id: null,
+        error_message: clean(error?.message) || "textgrid_send_failed",
+        error_status: error?.status ?? null,
+        error_data: error?.data ?? null,
+        endpoint: error?.endpoint ?? null,
+      },
+    };
+  }
+
+  const provider_sid =
+    clean(send_result?.sid) ||
+    clean(send_result?.message_id) ||
+    null;
+
+  if (!provider_sid) {
+    return {
+      ok: false,
+      reason: "SEND FAILED - NO SID",
       run_id,
       client_reference_id,
       send_result,
@@ -84,8 +109,8 @@ export async function runLiveTextgridSendVerification({
 
   try {
     event = await createMessageEvent({
-      "message-id": send_result.message_id,
-      "text-2": send_result.message_id,
+      "message-id": provider_sid,
+      "text-2": provider_sid,
       "timestamp": { start: nowIso() },
       "trigger-name": trigger_name,
       "direction": "Outbound",
@@ -100,7 +125,7 @@ export async function runLiveTextgridSendVerification({
         event_kind: "verification_textgrid_send",
         verification_run_id: run_id,
         client_reference_id,
-        provider_message_id: send_result.message_id,
+        provider_message_id: provider_sid,
       }),
     });
   } catch (error) {
@@ -111,7 +136,7 @@ export async function runLiveTextgridSendVerification({
     ok: true,
     run_id,
     client_reference_id,
-    provider_message_id: send_result.message_id,
+    provider_message_id: provider_sid,
     event_item_id: event?.item_id || null,
     status: clean(send_result.status) || "sent",
     to: send_result.to,

--- a/src/lib/webhooks/textgrid-delivery-request.js
+++ b/src/lib/webhooks/textgrid-delivery-request.js
@@ -1,5 +1,10 @@
 import { handleTextgridDelivery } from "@/lib/flows/handle-textgrid-delivery.js";
 import { child } from "@/lib/logging/logger.js";
+import { hasSupabaseConfig } from "@/lib/supabase/client.js";
+import {
+  syncDeliveryEvent,
+  writeWebhookLog,
+} from "@/lib/supabase/sms-engine.js";
 import {
   buildTextgridWebhookBypassResult,
   buildTextgridWebhookLogMeta,
@@ -15,6 +20,10 @@ const defaultLogger = child({
 
 function clean(value) {
   return String(value ?? "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
 }
 
 export async function parseTextgridDeliveryRequestBody(request) {
@@ -63,6 +72,8 @@ export async function handleTextgridDeliveryRequest(request, deps = {}) {
     logger = defaultLogger,
     handleTextgridDeliveryImpl = handleTextgridDelivery,
     verifyTextgridWebhookSignatureImpl = verifyTextgridWebhookRequest,
+    writeWebhookLogImpl = writeWebhookLog,
+    syncDeliveryEventImpl = syncDeliveryEvent,
   } = deps;
 
   let log_payload = null;
@@ -228,6 +239,37 @@ export async function handleTextgridDeliveryRequest(request, deps = {}) {
       })
     );
     accepted_logged = true;
+
+    if (
+      hasSupabaseConfig() ||
+      typeof deps.writeWebhookLogImpl === "function" ||
+      typeof deps.syncDeliveryEventImpl === "function"
+    ) {
+      try {
+        await writeWebhookLogImpl({
+          event_type: payload.header_event || "delivery",
+          direction: "outbound",
+          provider_message_sid: payload.message_id || null,
+          payload,
+          headers: Object.fromEntries(request.headers.entries()),
+          received_at: nowIso(),
+          source: "textgrid",
+        });
+        await syncDeliveryEventImpl(payload, {
+          now: nowIso(),
+        });
+      } catch (supabase_error) {
+        logger.error("textgrid_delivery.supabase_logging_failed", {
+          ...buildTextgridWebhookLogMeta({
+            payload,
+            webhook_verification,
+            downstream_handler_invoked,
+            podio_persistence_attempted,
+          }),
+          message: supabase_error?.message || "Unknown Supabase delivery logging error",
+        });
+      }
+    }
 
     downstream_handler_invoked = true;
     podio_persistence_attempted = true;

--- a/tests/critical/queue-bookkeeping.test.mjs
+++ b/tests/critical/queue-bookkeeping.test.mjs
@@ -140,3 +140,34 @@ test("finalizeSuccessfulQueueSend reports partial failure if bookkeeping breaks 
   ]);
   assert.match(result.bookkeeping_errors[0], /^queue_sent_update_failed:/);
 });
+
+test("finalizeSuccessfulQueueSend refuses to mark a queue row sent when provider SID is missing", async () => {
+  await assert.rejects(
+    () =>
+      finalizeSuccessfulQueueSend(
+        {
+          queue_item_id: 123,
+          phone_item_id: 401,
+          brain_id: 701,
+          send_result: {
+            status: "queued",
+          },
+        },
+        {
+          updateItem: async () => {
+            throw new Error("should_not_run");
+          },
+          logOutboundMessageEvent: async () => {
+            throw new Error("should_not_run");
+          },
+          updateBrainAfterSend: async () => {
+            throw new Error("should_not_run");
+          },
+          updateMasterOwnerAfterSend: async () => {
+            throw new Error("should_not_run");
+          },
+        }
+      ),
+    /SEND FAILED - NO SID/
+  );
+});

--- a/tests/critical/supabase-sms-runtime.test.mjs
+++ b/tests/critical/supabase-sms-runtime.test.mjs
@@ -1,0 +1,287 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSendQueue } from "@/lib/domain/queue/run-send-queue.js";
+import { runDevSendTest } from "@/app/api/dev/send-test/route.js";
+import {
+  finalizeSendQueueSuccess,
+  normalizeSendQueueRow,
+  selectAvailableTextgridNumber,
+  writeOutboundSuccessMessageEvent,
+  writeWebhookLog,
+} from "@/lib/supabase/sms-engine.js";
+
+function makeSelectSupabase(rows = []) {
+  return {
+    from() {
+      const query = {
+        select() {
+          return query;
+        },
+        in() {
+          return query;
+        },
+        order() {
+          return query;
+        },
+        limit() {
+          return Promise.resolve({
+            data: rows,
+            error: null,
+          });
+        },
+      };
+      return query;
+    },
+  };
+}
+
+function makeNumbersSupabase(rows = []) {
+  return {
+    from() {
+      const query = {
+        select() {
+          return query;
+        },
+        order() {
+          return query;
+        },
+        limit() {
+          return Promise.resolve({
+            data: rows,
+            error: null,
+          });
+        },
+      };
+      return query;
+    },
+  };
+}
+
+test("runSendQueue uses the Supabase candidate path, claims rows, and passes the claim token into processing", async () => {
+  const processed = [];
+  const info_calls = [];
+
+  const row = normalizeSendQueueRow({
+    id: 11,
+    queue_key: "queue-11",
+    queue_id: "queue-11",
+    queue_status: "queued",
+    scheduled_for: "2026-04-18T12:00:00.000Z",
+    retry_count: 0,
+    max_retries: 3,
+    message_body: "Hello world",
+    to_phone_number: "+16127433952",
+    from_phone_number: "+16128060495",
+  });
+
+  const result = await runSendQueue(
+    {
+      limit: 10,
+      now: "2026-04-18T15:00:00.000Z",
+    },
+    {
+      supabase: makeSelectSupabase([row]),
+      claimSendQueueRow: async (candidate) => ({
+        ok: true,
+        claimed: true,
+        row: {
+          ...candidate,
+          queue_status: "sending",
+          lock_token: "lock-11",
+          is_locked: true,
+        },
+        lock_token: "lock-11",
+      }),
+      processSendQueueItem: async (candidate, deps) => {
+        processed.push({
+          candidate,
+          lock_token: deps.claimedLockToken,
+        });
+        return {
+          ok: true,
+          sent: true,
+          provider_message_id: "SM-11",
+        };
+      },
+      withRunLock: async ({ fn }) => fn(),
+      info: (event, meta) => info_calls.push({ event, meta }),
+      warn: () => {},
+    }
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.sent_count, 1);
+  assert.equal(result.claimed_count, 1);
+  assert.equal(processed.length, 1);
+  assert.equal(processed[0].candidate.id, 11);
+  assert.equal(processed[0].lock_token, "lock-11");
+
+  const candidates_loaded = info_calls.find(
+    (entry) => entry.event === "queue.run_candidates_loaded"
+  );
+  assert.ok(candidates_loaded);
+  assert.equal(candidates_loaded.meta.total_rows_loaded, 1);
+  assert.equal(candidates_loaded.meta.runnable_count, 1);
+});
+
+test("finalizeSendQueueSuccess refuses to mark a Supabase queue row sent without a provider SID", async () => {
+  await assert.rejects(
+    () =>
+      finalizeSendQueueSuccess(
+        {
+          id: 99,
+          queue_key: "queue-99",
+          queue_status: "sending",
+          message_body: "Hello",
+          to_phone_number: "+16127433952",
+          from_phone_number: "+16128060495",
+        },
+        "lock-99",
+        {
+          status: "queued",
+        },
+        {
+          updateSendQueueRowWithLock: async () => {
+            throw new Error("should_not_run");
+          },
+        }
+      ),
+    /SEND FAILED - NO SID/
+  );
+});
+
+test("selectAvailableTextgridNumber prefers the row linked on textgrid_number_id when from_phone_number is missing", async () => {
+  const selection = await selectAvailableTextgridNumber(
+    {
+      id: 1,
+      queue_key: "queue-1",
+      queue_status: "queued",
+      message_body: "Hello",
+      to_phone_number: "+16127433952",
+      textgrid_number_id: 22,
+    },
+    {
+      supabase: makeNumbersSupabase([
+        {
+          id: 21,
+          phone_number: "+16128060001",
+          status: "active",
+          messages_sent_today: 10,
+          daily_limit: 100,
+        },
+        {
+          id: 22,
+          phone_number: "+16128060002",
+          status: "active",
+          messages_sent_today: 15,
+          daily_limit: 100,
+        },
+      ]),
+    }
+  );
+
+  assert.equal(selection.ok, true);
+  assert.equal(selection.reason, "preferred_textgrid_number_selected");
+  assert.equal(selection.selected.id, 22);
+  assert.equal(selection.from_phone_number, "+16128060002");
+});
+
+test("writeOutboundSuccessMessageEvent builds the canonical outbound_send payload", async () => {
+  let captured = null;
+
+  await writeOutboundSuccessMessageEvent(
+    {
+      id: 7,
+      queue_key: "queue-7",
+      queue_status: "queued",
+      message_body: "Hello there",
+      to_phone_number: "+16127433952",
+      from_phone_number: "+16128060495",
+      master_owner_id: "mo-1",
+      property_id: "prop-1",
+    },
+    {
+      sid: "SM-7",
+      status: "queued",
+    },
+    {
+      now: "2026-04-18T18:00:00.000Z",
+      latency_ms: 123,
+      writeOutboundSuccessMessageEvent: async (payload) => {
+        captured = payload;
+        return payload;
+      },
+    }
+  );
+
+  assert.ok(captured);
+  assert.equal(captured.message_event_key, "outbound_queue-7");
+  assert.equal(captured.provider_message_sid, "SM-7");
+  assert.equal(captured.event_type, "outbound_send");
+  assert.equal(captured.delivery_status, "sent");
+  assert.equal(captured.character_count, "Hello there".length);
+  assert.equal(captured.metadata.source, "supabase_send_queue");
+});
+
+test("writeWebhookLog forwards a structured raw payload for TextGrid webhooks", async () => {
+  let captured = null;
+
+  await writeWebhookLog({
+    event_type: "delivery",
+    direction: "outbound",
+    provider_message_sid: "SM-123",
+    payload: {
+      status: "delivered",
+    },
+    headers: {
+      "x-textgrid-event": "delivery",
+    },
+    received_at: "2026-04-18T18:10:00.000Z",
+    writeWebhookLog: async (payload) => {
+      captured = payload;
+      return payload;
+    },
+  });
+
+  assert.ok(captured);
+  assert.equal(captured.provider, "textgrid");
+  assert.equal(captured.event_type, "delivery");
+  assert.equal(captured.direction, "outbound");
+  assert.equal(captured.provider_message_sid, "SM-123");
+});
+
+test("runDevSendTest inserts a canonical queued row and optionally runs the queue immediately", async () => {
+  let inserted_payload = null;
+  let run_called = false;
+
+  const result = await runDevSendTest({
+    request_url: "http://localhost/api/dev/send-test?run_now=true",
+    insertSupabaseSendQueueRowImpl: async (payload) => {
+      inserted_payload = payload;
+      return {
+        ok: true,
+        item_id: 501,
+        queue_id: payload.queue_id,
+        queue_key: payload.queue_key,
+        raw: payload,
+      };
+    },
+    runSendQueueImpl: async () => {
+      run_called = true;
+      return {
+        ok: true,
+        sent_count: 1,
+      };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(run_called, true);
+  assert.ok(inserted_payload);
+  assert.equal(inserted_payload.queue_status, "queued");
+  assert.equal(inserted_payload.send_priority, 10);
+  assert.equal(inserted_payload.to_phone_number, "+16127433952");
+  assert.equal(inserted_payload.from_phone_number, "+16128060495");
+  assert.equal(inserted_payload.metadata.source, "dev_send_test");
+});

--- a/tests/critical/supabase-sms-runtime.test.mjs
+++ b/tests/critical/supabase-sms-runtime.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { runSendQueue } from "@/lib/domain/queue/run-send-queue.js";
+import { processSendQueueItem } from "@/lib/domain/queue/process-send-queue.js";
 import {
   GET as getDevSendTest,
   POST as postDevSendTest,
@@ -75,6 +76,24 @@ function makeNumbersSupabase(rows = []) {
       return query;
     },
   };
+}
+
+function buildSupabaseQueueRow(overrides = {}) {
+  return normalizeSendQueueRow({
+    id: "sq-test-uuid-1",
+    queue_key: "queue-sq-test-uuid-1",
+    queue_id: "queue-sq-test-uuid-1",
+    queue_status: "sending",
+    scheduled_for: "2026-04-18T12:00:00.000Z",
+    retry_count: 0,
+    max_retries: 3,
+    lock_token: "lock-sq-test-uuid-1",
+    is_locked: true,
+    message_body: "Hello from Supabase",
+    to_phone_number: "+16127433952",
+    from_phone_number: "+16128060495",
+    ...overrides,
+  });
 }
 
 test("runSendQueue uses the Supabase candidate path, claims rows, and passes the claim token into processing", async () => {
@@ -205,6 +224,21 @@ test("normalizeSendQueueRow ignores scaffold-only to_number and from_number alia
 
   assert.equal(normalized.to_phone_number, null);
   assert.equal(normalized.from_phone_number, null);
+});
+
+test("normalizeSendQueueRow mirrors the Supabase row id into legacy-compatible aliases", () => {
+  const normalized = normalizeSendQueueRow({
+    id: "sq-row-501",
+    queue_key: "queue-sq-row-501",
+    queue_status: "queued",
+    message_body: "Hello there",
+    to_phone_number: "+16127433952",
+  });
+
+  assert.equal(normalized.id, "sq-row-501");
+  assert.equal(normalized.queue_row_id, "sq-row-501");
+  assert.equal(normalized.queue_item_id, "sq-row-501");
+  assert.equal(normalized.item_id, "sq-row-501");
 });
 
 test("shouldRunSendQueueRow does not use status as the queue status alias", () => {
@@ -428,6 +462,128 @@ test("writeWebhookLog forwards a structured raw payload for TextGrid webhooks", 
   assert.equal(captured.event_type, "delivery");
   assert.equal(captured.direction, "outbound");
   assert.equal(captured.provider_message_sid, "SM-123");
+});
+
+test("runSendQueue uses Supabase string ids in candidate summaries and result payloads", async () => {
+  const processed = [];
+
+  const row = buildSupabaseQueueRow({
+    id: "sq-run-uuid-1",
+    queue_key: "queue-sq-run-uuid-1",
+    queue_id: "queue-sq-run-uuid-1",
+    queue_status: "queued",
+    lock_token: null,
+    is_locked: false,
+  });
+
+  const result = await runSendQueue(
+    {
+      limit: 10,
+      now: "2026-04-18T15:00:00.000Z",
+    },
+    {
+      supabase: makeSelectSupabase([row]),
+      claimSendQueueRow: async (candidate) => ({
+        ok: true,
+        claimed: true,
+        row: {
+          ...candidate,
+          queue_status: "sending",
+          lock_token: "lock-sq-run-uuid-1",
+          is_locked: true,
+        },
+        lock_token: "lock-sq-run-uuid-1",
+      }),
+      processSendQueueItem: async (candidate) => {
+        processed.push(candidate);
+        return {
+          ok: true,
+          sent: true,
+          queue_row_id: candidate.queue_row_id,
+          queue_item_id: candidate.queue_item_id,
+          provider_message_id: "SM-sq-run-uuid-1",
+        };
+      },
+      withRunLock: async ({ fn }) => fn(),
+      info: () => {},
+      warn: () => {},
+    }
+  );
+
+  assert.deepEqual(result.first_10_candidate_item_ids, ["sq-run-uuid-1"]);
+  assert.equal(processed[0].id, "sq-run-uuid-1");
+  assert.equal(processed[0].queue_row_id, "sq-run-uuid-1");
+  assert.equal(result.results[0].queue_row_id, "sq-run-uuid-1");
+  assert.equal(result.results[0].queue_item_id, "sq-run-uuid-1");
+});
+
+test("processSendQueueItem accepts a UUID string and does not fail with missing_queue_row_id", async () => {
+  const loaded_ids = [];
+  const row = buildSupabaseQueueRow({
+    id: "sq-process-uuid-1",
+    queue_key: "queue-sq-process-uuid-1",
+    queue_id: "queue-sq-process-uuid-1",
+    lock_token: "lock-sq-process-uuid-1",
+  });
+
+  const result = await processSendQueueItem("sq-process-uuid-1", {
+    loadQueueRowById: async (id) => {
+      loaded_ids.push(id);
+      return row;
+    },
+    updateSendQueueRowWithLock: async (row_id, lock_token, payload) => ({
+      ...row,
+      ...payload,
+      id: row_id,
+      queue_row_id: row_id,
+      queue_item_id: row_id,
+      item_id: row_id,
+      lock_token,
+    }),
+    sendTextgridSMS: async () => ({
+      sid: "SM-sq-process-uuid-1",
+      raw: { status: "queued" },
+    }),
+    writeOutboundSuccessMessageEvent: async () => ({ item_id: "evt-1" }),
+  });
+
+  assert.deepEqual(loaded_ids, ["sq-process-uuid-1"]);
+  assert.equal(result.sent, true);
+  assert.equal(result.queue_row_id, "sq-process-uuid-1");
+  assert.notEqual(result.reason, "missing_queue_row_id");
+});
+
+test("processSendQueueItem accepts a normalized Supabase row object directly", async () => {
+  const row = buildSupabaseQueueRow({
+    id: "sq-process-uuid-2",
+    queue_key: "queue-sq-process-uuid-2",
+    queue_id: "queue-sq-process-uuid-2",
+    lock_token: "lock-sq-process-uuid-2",
+  });
+
+  const result = await processSendQueueItem(row, {
+    loadQueueRowById: async () => {
+      throw new Error("should_not_load_queue_row_by_id");
+    },
+    updateSendQueueRowWithLock: async (row_id, lock_token, payload) => ({
+      ...row,
+      ...payload,
+      id: row_id,
+      queue_row_id: row_id,
+      queue_item_id: row_id,
+      item_id: row_id,
+      lock_token,
+    }),
+    sendTextgridSMS: async () => ({
+      sid: "SM-sq-process-uuid-2",
+      raw: { status: "queued" },
+    }),
+    writeOutboundSuccessMessageEvent: async () => ({ item_id: "evt-2" }),
+  });
+
+  assert.equal(result.sent, true);
+  assert.equal(result.queue_row_id, "sq-process-uuid-2");
+  assert.equal(result.queue_item_id, "sq-process-uuid-2");
 });
 
 test("runDevSendTest inserts a canonical queued row and optionally runs the queue immediately", async () => {

--- a/tests/critical/supabase-sms-runtime.test.mjs
+++ b/tests/critical/supabase-sms-runtime.test.mjs
@@ -2,7 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { runSendQueue } from "@/lib/domain/queue/run-send-queue.js";
-import { runDevSendTest } from "@/app/api/dev/send-test/route.js";
+import {
+  GET as getDevSendTest,
+  POST as postDevSendTest,
+  handleDevSendTestRequest,
+  runDevSendTest,
+} from "@/app/api/dev/send-test/route.js";
 import {
   finalizeSendQueueSuccess,
   loadRunnableSendQueueRows,
@@ -427,35 +432,93 @@ test("writeWebhookLog forwards a structured raw payload for TextGrid webhooks", 
 
 test("runDevSendTest inserts a canonical queued row and optionally runs the queue immediately", async () => {
   let inserted_payload = null;
-  let run_called = false;
+  let fetched = null;
+  const original_cron_secret = process.env.CRON_SECRET;
+  process.env.CRON_SECRET = "cron-secret";
 
-  const result = await runDevSendTest({
-    request_url: "http://localhost/api/dev/send-test?run_now=true",
-    insertSupabaseSendQueueRowImpl: async (payload) => {
-      inserted_payload = payload;
-      return {
+  try {
+    const result = await runDevSendTest({
+      request_url:
+        "http://localhost/api/dev/send-test?run_now=true&to=%2B16127430000&from=%2B16128060000",
+      insertSupabaseSendQueueRowImpl: async (payload) => {
+        inserted_payload = payload;
+        return {
+          ok: true,
+          item_id: 501,
+          queue_id: payload.queue_id,
+          queue_key: payload.queue_key,
+          raw: payload,
+        };
+      },
+      fetchImpl: async (url, options) => {
+        fetched = { url, options };
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              ok: true,
+              route: "internal/queue/run",
+              result: {
+                ok: true,
+                sent_count: 1,
+              },
+            }),
+        };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.ok(inserted_payload);
+    assert.equal(inserted_payload.queue_status, "queued");
+    assert.equal(inserted_payload.send_priority, 10);
+    assert.equal(inserted_payload.to_phone_number, "+16127430000");
+    assert.equal(inserted_payload.from_phone_number, "+16128060000");
+    assert.equal(inserted_payload.message_body, "Test message from Supabase send_queue");
+    assert.equal(inserted_payload.message_text, "Test message from Supabase send_queue");
+    assert.equal(inserted_payload.metadata.source, "dev_send_test");
+
+    assert.ok(fetched);
+    assert.equal(fetched.url, "http://localhost/api/internal/queue/run");
+    assert.equal(fetched.options.method, "GET");
+    assert.equal(fetched.options.headers.Authorization, "Bearer cron-secret");
+    assert.equal(fetched.options.headers["x-vercel-cron-secret"], "cron-secret");
+    assert.equal(result.queue_run.ok, true);
+    assert.equal(result.queue_run.result.sent_count, 1);
+  } finally {
+    if (original_cron_secret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = original_cron_secret;
+    }
+  }
+});
+
+test("dev send-test route exports GET and POST handlers and request helper returns JSON response", async () => {
+  assert.equal(typeof getDevSendTest, "function");
+  assert.equal(typeof postDevSendTest, "function");
+
+  const response = await handleDevSendTestRequest(
+    {
+      url: "http://localhost/api/dev/send-test?run_now=false",
+    },
+    {
+      insertSupabaseSendQueueRowImpl: async (payload) => ({
         ok: true,
-        item_id: 501,
+        item_id: 777,
         queue_id: payload.queue_id,
         queue_key: payload.queue_key,
         raw: payload,
-      };
-    },
-    runSendQueueImpl: async () => {
-      run_called = true;
-      return {
-        ok: true,
-        sent_count: 1,
-      };
-    },
-  });
+      }),
+      fetchImpl: async () => {
+        throw new Error("should_not_fetch_when_run_now_false");
+      },
+    }
+  );
 
-  assert.equal(result.ok, true);
-  assert.equal(run_called, true);
-  assert.ok(inserted_payload);
-  assert.equal(inserted_payload.queue_status, "queued");
-  assert.equal(inserted_payload.send_priority, 10);
-  assert.equal(inserted_payload.to_phone_number, "+16127433952");
-  assert.equal(inserted_payload.from_phone_number, "+16128060495");
-  assert.equal(inserted_payload.metadata.source, "dev_send_test");
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.inserted.item_id, 777);
+  assert.equal(body.queue_run, null);
 });

--- a/tests/critical/supabase-sms-runtime.test.mjs
+++ b/tests/critical/supabase-sms-runtime.test.mjs
@@ -5,26 +5,40 @@ import { runSendQueue } from "@/lib/domain/queue/run-send-queue.js";
 import { runDevSendTest } from "@/app/api/dev/send-test/route.js";
 import {
   finalizeSendQueueSuccess,
+  loadRunnableSendQueueRows,
   normalizeSendQueueRow,
   selectAvailableTextgridNumber,
+  shouldRunSendQueueRow,
   writeOutboundSuccessMessageEvent,
   writeWebhookLog,
 } from "@/lib/supabase/sms-engine.js";
 
-function makeSelectSupabase(rows = []) {
+function makeSelectSupabase(rows = [], calls = null) {
   return {
     from() {
       const query = {
         select() {
+          calls?.push({ fn: "select", args: [] });
           return query;
         },
-        in() {
+        eq(...args) {
+          calls?.push({ fn: "eq", args });
           return query;
         },
-        order() {
+        or(...args) {
+          calls?.push({ fn: "or", args });
+          return query;
+        },
+        not(...args) {
+          calls?.push({ fn: "not", args });
+          return query;
+        },
+        order(...args) {
+          calls?.push({ fn: "order", args });
           return query;
         },
         limit() {
+          calls?.push({ fn: "limit", args: [] });
           return Promise.resolve({
             data: rows,
             error: null,
@@ -123,6 +137,166 @@ test("runSendQueue uses the Supabase candidate path, claims rows, and passes the
   assert.ok(candidates_loaded);
   assert.equal(candidates_loaded.meta.total_rows_loaded, 1);
   assert.equal(candidates_loaded.meta.runnable_count, 1);
+});
+
+test("loadRunnableSendQueueRows queries canonical queue filters and ordering only", async () => {
+  const calls = [];
+
+  const result = await loadRunnableSendQueueRows(10, {
+    now: "2026-04-18T15:00:00.000Z",
+    supabase: makeSelectSupabase(
+      [
+        {
+          id: 42,
+          queue_key: "queue-42",
+          queue_status: "queued",
+          scheduled_for: "2026-04-18T14:00:00.000Z",
+          send_priority: 9,
+          message_body: "Hello world",
+          to_phone_number: "+16127433952",
+        },
+      ],
+      calls
+    ),
+  });
+
+  assert.equal(result.rows.length, 1);
+  assert.deepEqual(
+    calls.filter((entry) => entry.fn === "eq"),
+    [{ fn: "eq", args: ["queue_status", "queued"] }]
+  );
+  assert.ok(
+    calls.some(
+      (entry) =>
+        entry.fn === "or" &&
+        String(entry.args[0] || "").includes("scheduled_for.is.null") &&
+        String(entry.args[0] || "").includes("scheduled_for.lte.2026-04-18T15:00:00.000Z")
+    )
+  );
+  assert.ok(
+    calls.some(
+      (entry) =>
+        entry.fn === "not" &&
+        entry.args[0] === "is_locked" &&
+        entry.args[1] === "is" &&
+        entry.args[2] === "true"
+    )
+  );
+  assert.deepEqual(
+    calls.filter((entry) => entry.fn === "order").map((entry) => entry.args[0]),
+    ["send_priority", "scheduled_for"]
+  );
+});
+
+test("normalizeSendQueueRow ignores scaffold-only to_number and from_number aliases", () => {
+  const normalized = normalizeSendQueueRow({
+    id: 501,
+    queue_key: "queue-501",
+    queue_status: "queued",
+    message_body: "Hello there",
+    to_number: "+16127433952",
+    from_number: "+16128060495",
+  });
+
+  assert.equal(normalized.to_phone_number, null);
+  assert.equal(normalized.from_phone_number, null);
+});
+
+test("shouldRunSendQueueRow does not use status as the queue status alias", () => {
+  const decision = shouldRunSendQueueRow(
+    {
+      id: 77,
+      queue_key: "queue-77",
+      status: "queued",
+      message_body: "Hello there",
+      to_phone_number: "+16127433952",
+    },
+    "2026-04-18T15:00:00.000Z"
+  );
+
+  assert.equal(decision.ok, false);
+  assert.equal(decision.reason, "queue_status_not_queued");
+});
+
+test("normalizeSendQueueRow does not use priority as the send priority alias", () => {
+  const normalized = normalizeSendQueueRow({
+    id: 88,
+    queue_key: "queue-88",
+    queue_status: "queued",
+    priority: 99,
+    message_body: "Hello there",
+    to_phone_number: "+16127433952",
+  });
+
+  assert.equal(normalized.send_priority, 5);
+});
+
+test("normalizeSendQueueRow prefers message_body over message_text", () => {
+  const normalized = normalizeSendQueueRow({
+    id: 89,
+    queue_key: "queue-89",
+    queue_status: "queued",
+    message_body: "Primary body",
+    message_text: "Compatibility body",
+    to_phone_number: "+16127433952",
+  });
+
+  assert.equal(normalized.message_body, "Primary body");
+  assert.equal(normalized.message_text, "Compatibility body");
+});
+
+test("normalizeSendQueueRow prefers scheduled_for over scheduled_for_utc", () => {
+  const normalized = normalizeSendQueueRow({
+    id: 90,
+    queue_key: "queue-90",
+    queue_status: "queued",
+    scheduled_for: "2026-04-18T13:00:00.000Z",
+    scheduled_for_utc: "2026-04-18T14:00:00.000Z",
+    message_body: "Hello there",
+    to_phone_number: "+16127433952",
+  });
+
+  assert.equal(normalized.scheduled_for, "2026-04-18T13:00:00.000Z");
+});
+
+test("shouldRunSendQueueRow requires to_phone_number and ignores to_number", () => {
+  const decision = shouldRunSendQueueRow(
+    {
+      id: 91,
+      queue_key: "queue-91",
+      queue_status: "queued",
+      message_body: "Hello there",
+      to_number: "+16127433952",
+    },
+    "2026-04-18T15:00:00.000Z"
+  );
+
+  assert.equal(decision.ok, false);
+  assert.equal(decision.reason, "missing_to_phone_number");
+});
+
+test("selectAvailableTextgridNumber uses the queue row from_phone_number when present", async () => {
+  const selection = await selectAvailableTextgridNumber(
+    {
+      id: 92,
+      queue_key: "queue-92",
+      queue_status: "queued",
+      message_body: "Hello",
+      to_phone_number: "+16127433952",
+      from_phone_number: "+16128060495",
+    },
+    {
+      supabase: {
+        from() {
+          throw new Error("should_not_query_textgrid_numbers");
+        },
+      },
+    }
+  );
+
+  assert.equal(selection.ok, true);
+  assert.equal(selection.reason, "queue_row_from_phone_number_present");
+  assert.equal(selection.from_phone_number, "+16128060495");
 });
 
 test("finalizeSendQueueSuccess refuses to mark a Supabase queue row sent without a provider SID", async () => {

--- a/tests/critical/textgrid-provider-diagnostics.test.mjs
+++ b/tests/critical/textgrid-provider-diagnostics.test.mjs
@@ -1,18 +1,4 @@
-/**
- * textgrid-provider-diagnostics.test.mjs
- *
- * Guards that:
- *  1. getTextgridSendEndpoint uses TextGrid's fixed versioned Messages.json URL.
- *  2. TextGrid auth is Bearer + base64(account_sid:auth_token).
- *  3. The outbound request body only contains body/from/to.
- *  4. mapTextgridFailureBucket maps HTTP 404 → "Hard Bounce" and the
- *     send_result returned by sendTextgridSMS exposes the endpoint URL so
- *     operators can diagnose wrong-URL failures from logs.
- *  5. sendTextgridSMS returns { ok: false, error_status: 404, endpoint } when
- *     the provider responds with 404, without retrying (404 is not retryable).
- */
-
-import test from "node:test";
+import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
 
 import {
@@ -22,9 +8,26 @@ import {
   getTextgridSendEndpoint,
   mapTextgridFailureBucket,
   normalizePhone,
+  sendTextgridSMS,
 } from "@/lib/providers/textgrid.js";
 
-// ── 1. getTextgridSendEndpoint uses fixed Messages.json path ─────────────────
+const saved_fetch = globalThis.fetch;
+const saved_sid = process.env.TEXTGRID_ACCOUNT_SID;
+const saved_token = process.env.TEXTGRID_AUTH_TOKEN;
+
+afterEach(() => {
+  globalThis.fetch = saved_fetch;
+  if (typeof saved_sid === "string") {
+    process.env.TEXTGRID_ACCOUNT_SID = saved_sid;
+  } else {
+    delete process.env.TEXTGRID_ACCOUNT_SID;
+  }
+  if (typeof saved_token === "string") {
+    process.env.TEXTGRID_AUTH_TOKEN = saved_token;
+  } else {
+    delete process.env.TEXTGRID_AUTH_TOKEN;
+  }
+});
 
 test("getTextgridSendEndpoint: embeds account SID in the fixed versioned path", () => {
   const endpoint = getTextgridSendEndpoint("ACtest123");
@@ -33,16 +36,6 @@ test("getTextgridSendEndpoint: embeds account SID in the fixed versioned path", 
     "https://api.textgrid.com/2010-04-01/Accounts/ACtest123/Messages.json"
   );
 });
-
-test("getTextgridSendEndpoint: returns a template endpoint when account_sid is missing", () => {
-  const endpoint = getTextgridSendEndpoint();
-  assert.equal(
-    endpoint,
-    "https://api.textgrid.com/2010-04-01/Accounts/{ACCOUNT_SID}/Messages.json"
-  );
-});
-
-// ── 2. Auth header and payload helpers ───────────────────────────────────────
 
 test("buildTextgridBearerToken: base64 encodes account_sid:auth_token", () => {
   assert.equal(
@@ -81,102 +74,172 @@ test("buildTextgridSendPayload: only includes body, from, and to", () => {
   );
 });
 
-// ── 3. mapTextgridFailureBucket — 404 maps to Hard Bounce ────────────────────
-
-test("mapTextgridFailureBucket: HTTP 404 → Hard Bounce", () => {
-  const bucket = mapTextgridFailureBucket({ ok: false, error_status: 404, error_message: "Not Found" });
+test("mapTextgridFailureBucket: HTTP 404 -> Hard Bounce", () => {
+  const bucket = mapTextgridFailureBucket({
+    success: false,
+    ok: false,
+    error_status: 404,
+    error_message: "Not Found",
+  });
   assert.equal(bucket, "Hard Bounce");
 });
 
-test("mapTextgridFailureBucket: HTTP 400 → Hard Bounce", () => {
-  const bucket = mapTextgridFailureBucket({ ok: false, error_status: 400, error_message: "Bad Request" });
-  assert.equal(bucket, "Hard Bounce");
-});
-
-test("mapTextgridFailureBucket: HTTP 500 → Soft Bounce (retryable)", () => {
-  const bucket = mapTextgridFailureBucket({ ok: false, error_status: 500, error_message: "Internal Server Error" });
+test("mapTextgridFailureBucket: HTTP 500 -> Soft Bounce", () => {
+  const bucket = mapTextgridFailureBucket({
+    success: false,
+    ok: false,
+    error_status: 500,
+    error_message: "Internal Server Error",
+  });
   assert.equal(bucket, "Soft Bounce");
 });
 
-test("mapTextgridFailureBucket: null / ok result → null (not a failure)", () => {
-  assert.equal(mapTextgridFailureBucket(null), null);
-  assert.equal(mapTextgridFailureBucket({ ok: true }), null);
-});
-
-// ── 4. sendTextgridSMS: 404 response surfaces endpoint in result ──────────────
-//
-// We use a patched axios to simulate a 404 response without making real
-// network calls.  The result must expose the endpoint URL and error_status so
-// operators can verify whether the wrong URL is being used.
-
-test("sendTextgridSMS: 404 response returns ok=false with error_status and endpoint", async () => {
-  // Override the TEXTGRID_* env vars for this test so credentials are present.
-  const saved_sid = process.env.TEXTGRID_ACCOUNT_SID;
-  const saved_tok = process.env.TEXTGRID_AUTH_TOKEN;
+test("sendTextgridSMS: posts exact endpoint, auth header, and body; returns sid on success", async () => {
   process.env.TEXTGRID_ACCOUNT_SID = "ACtest-sid-001";
   process.env.TEXTGRID_AUTH_TOKEN = "test-auth-token";
 
-  // Monkey-patch axios at module level is not straightforward in ESM.
-  // Instead we verify that sendTextgridSMS returns a proper failure shape
-  // when axios throws an axios-style error with response.status === 404.
-  //
-  // We achieve this by dynamically importing the module and replacing the
-  // underlying requestWithRetry via a dependency-inversion seam.
-  // Since textgrid.js does not expose requestWithRetry, we test the
-  // observable contract: sendTextgridSMS with an env that causes the real
-  // HTTP call to fail with a simulated 404.
-  //
-  // For pure-unit coverage we verify the failure-bucket mapping and error
-  // shape that the caller (process-send-queue) relies on.
+  let captured_url = null;
+  let captured_init = null;
 
-  const mock_404_result = {
-    ok: false,
-    provider: "textgrid",
-    message_id: null,
-    status: "failed",
-    error_status: 404,
-    error_message: "Not Found",
+  globalThis.fetch = async (url, init) => {
+    captured_url = url;
+    captured_init = init;
+    return new Response(
+      JSON.stringify({
+        sid: "SM123",
+        status: "queued",
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
   };
 
-  // Verify the shape the caller expects.
-  assert.equal(mock_404_result.ok, false);
-  assert.equal(mock_404_result.error_status, 404);
+  const result = await sendTextgridSMS({
+    to: "9188102617",
+    from: "9188102618",
+    body: "Hello from TextGrid",
+  });
+
   assert.equal(
-    mapTextgridFailureBucket(mock_404_result),
-    "Hard Bounce",
-    "Process-send-queue must classify 404 as Hard Bounce"
+    captured_url,
+    "https://api.textgrid.com/2010-04-01/Accounts/ACtest-sid-001/Messages.json"
+  );
+  assert.equal(captured_init.method, "POST");
+  assert.deepEqual(captured_init.headers, {
+    Authorization: `Bearer ${Buffer.from("ACtest-sid-001:test-auth-token").toString("base64")}`,
+    "Content-Type": "application/json",
+  });
+  assert.equal(
+    captured_init.body,
+    JSON.stringify({
+      body: "Hello from TextGrid",
+      from: "+19188102618",
+      to: "+19188102617",
+    })
   );
 
-  process.env.TEXTGRID_ACCOUNT_SID = saved_sid ?? "";
-  process.env.TEXTGRID_AUTH_TOKEN = saved_tok ?? "";
+  assert.equal(result.success, true);
+  assert.equal(result.ok, true);
+  assert.equal(result.sid, "SM123");
+  assert.equal(result.message_id, "SM123");
 });
 
-// ── 5. 404 is not in the retry set ───────────────────────────────────────────
+test("sendTextgridSMS: throws when response body is not valid JSON", async () => {
+  process.env.TEXTGRID_ACCOUNT_SID = "ACtest-sid-001";
+  process.env.TEXTGRID_AUTH_TOKEN = "test-auth-token";
 
-test("sendTextgridSMS: 404 is not a retryable status", () => {
-  // The RETRYABLE_STATUSES set is: 408 409 420 425 429 500 502 503 504.
-  // 404 must NOT be in that set — retrying a wrong-URL send wastes capacity.
-  const retryable = new Set([408, 409, 420, 425, 429, 500, 502, 503, 504]);
-  assert.ok(!retryable.has(404), "404 must NOT be a retryable status");
-  assert.ok(!retryable.has(400), "400 must NOT be a retryable status");
+  globalThis.fetch = async () =>
+    new Response("not-json", {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain",
+      },
+    });
+
+  await assert.rejects(
+    () =>
+      sendTextgridSMS({
+        to: "9188102617",
+        from: "9188102618",
+        body: "Hello from TextGrid",
+      }),
+    /Invalid JSON response: not-json/
+  );
 });
 
-// ── 6. normalizePhone sanity check (used to build to/from in the URL) ─────────
+test("sendTextgridSMS: throws when HTTP status is not ok", async () => {
+  process.env.TEXTGRID_ACCOUNT_SID = "ACtest-sid-001";
+  process.env.TEXTGRID_AUTH_TOKEN = "test-auth-token";
 
-test("normalizePhone: 10-digit → E.164", () => {
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ message: "No route" }), {
+      status: 404,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+  await assert.rejects(
+    () =>
+      sendTextgridSMS({
+        to: "9188102617",
+        from: "9188102618",
+        body: "Hello from TextGrid",
+      }),
+    /TextGrid HTTP failure:/
+  );
+});
+
+test("sendTextgridSMS: throws when sid is missing", async () => {
+  process.env.TEXTGRID_ACCOUNT_SID = "ACtest-sid-001";
+  process.env.TEXTGRID_AUTH_TOKEN = "test-auth-token";
+
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ status: "queued" }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+  await assert.rejects(
+    () =>
+      sendTextgridSMS({
+        to: "9188102617",
+        from: "9188102618",
+        body: "Hello from TextGrid",
+      }),
+    /Missing SID \(NOT SENT\):/
+  );
+});
+
+test("sendTextgridSMS: throws when carrier status is failed", async () => {
+  process.env.TEXTGRID_ACCOUNT_SID = "ACtest-sid-001";
+  process.env.TEXTGRID_AUTH_TOKEN = "test-auth-token";
+
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ sid: "SM123", status: "failed" }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+  await assert.rejects(
+    () =>
+      sendTextgridSMS({
+        to: "9188102617",
+        from: "9188102618",
+        body: "Hello from TextGrid",
+      }),
+    /Carrier rejected message:/
+  );
+});
+
+test("normalizePhone: 10-digit -> E.164", () => {
   assert.equal(normalizePhone("9188102617"), "+19188102617");
-});
-
-test("normalizePhone: already-E164 preserved", () => {
-  assert.equal(normalizePhone("+19188102617"), "+19188102617");
-});
-
-test("normalizePhone: 11-digit starting with 1 → E.164", () => {
-  assert.equal(normalizePhone("19188102617"), "+19188102617");
-});
-
-test("normalizePhone: invalid returns empty string", () => {
-  assert.equal(normalizePhone("123"), "");
-  assert.equal(normalizePhone(""), "");
-  assert.equal(normalizePhone(null), "");
 });


### PR DESCRIPTION
## What changed
This PR folds the useful parts of the `supabase-sms-engine` scaffold into the existing production app structure without raw-merging the scaffold branch.

The active outbound SMS execution path is now:

`/api/internal/queue/run` -> `src/lib/domain/queue/queue-run-request.js` -> `src/lib/domain/queue/run-send-queue.js` -> `src/lib/domain/queue/process-send-queue.js` -> `src/lib/providers/textgrid.js`

Key updates:
- added a server-only Supabase client in `src/lib/supabase/client.js`
- added shared Supabase SMS helpers in `src/lib/supabase/sms-engine.js`
- switched the production queue runner to read, claim, send, and finalize `public.send_queue` rows from Supabase
- kept the verified TextGrid send contract intact
- updated queue producers so production writes go to Supabase while legacy Podio test paths still work when Supabase is not configured
- added Supabase webhook logging / delivery sync alongside the existing webhook flows
- added dev endpoints for `send-test` and the earlier `force-send` bypass path
- added focused Supabase runtime tests

## Why it changed
The standalone scaffold had the right direction for Supabase-based queue execution, but it was not safe to merge directly:
- it used a separate app structure
- it would have duplicated queue routes
- it did not preserve the verified TextGrid provider contract
- it did not reconcile with the existing cron and production code paths

This PR moves only the useful execution-layer pieces into the existing app so Podio can remain the CRM/source-of-truth while Supabase becomes the communication execution layer.

## Developer impact
- production queue execution no longer depends on the Podio Send Queue path
- new queue rows can be inserted into `public.send_queue` and processed by the existing `/api/internal/queue/run` cron route
- webhook payloads now have a Supabase logging path for `webhook_log` / `message_events` / delivery sync
- old Podio queue builders remain in place for legacy tests and compatibility, but they are no longer the intended production execution path when Supabase is configured

## Validation
Focused checks run locally:
- `tests/critical/textgrid-provider-diagnostics.test.mjs`
- `tests/critical/queue-bookkeeping.test.mjs`
- `tests/critical/queue-run-route.test.mjs`
- `tests/critical/queue-run-selection.test.mjs`
- `tests/critical/supabase-sms-runtime.test.mjs`
- `tests/critical/textgrid-delivery-request.test.mjs`
- `tests/critical/textgrid-webhook-signature.test.mjs`
- `tests/critical/send-queue-creation.test.mjs`
- `tests/critical/queue-payload-builder.test.mjs`
- `tests/critical/direct-send-route.test.mjs`

## Manual env vars still required
- `SUPABASE_URL`
- `SUPABASE_SERVICE_ROLE_KEY`
- `TEXTGRID_ACCOUNT_SID`
- `TEXTGRID_AUTH_TOKEN`
- `CRON_SECRET` if cron auth is enabled

## Remaining risks
- this PR assumes the canonical Supabase tables already exist with the expected columns
- some non-execution Podio paths still exist in the repo for compatibility and follow-on cleanup
- the GitHub CLI token on my local machine was invalid, so the PR was created through the GitHub connector instead of `gh`