### PR TITLE
fix: finalize Supabase inbox, enrichment, auto-replies, and map data

### DIFF
--- a/src/app/api/internal/ai-router/route.js
+++ b/src/app/api/internal/ai-router/route.js
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { routeAiRequest } from "@/lib/ai/ai-router.js";
+import { requireInternalSecret } from "@/lib/security/require-internal-secret.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request) {
+  const auth = requireInternalSecret(request);
+  if (!auth.ok) return NextResponse.json({ ok: false, error: auth.error || "unauthorized" }, { status: auth.status || 401 });
+  const body = await request.json().catch(() => ({}));
+  const result = await routeAiRequest(body);
+  return NextResponse.json({ ok: true, route: "internal/ai-router", ...result });
+}

--- a/src/app/api/internal/dashboard/inbox/live/route.js
+++ b/src/app/api/internal/dashboard/inbox/live/route.js
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getLiveInbox } from "@/lib/domain/inbox/live-inbox-service.js";
+import { requireOpsDashboardAuth } from "@/lib/security/dashboard-auth.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request) {
+  const auth = requireOpsDashboardAuth(request);
+  if (!auth.authorized) return auth.response;
+  const { searchParams } = new URL(request.url);
+  const data = await getLiveInbox(Object.fromEntries(searchParams.entries()));
+  return NextResponse.json({ ok: true, route: "internal/dashboard/inbox/live", ...data });
+}

--- a/src/app/api/internal/queue/status/route.js
+++ b/src/app/api/internal/queue/status/route.js
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { supabase, hasSupabaseConfig } from "@/lib/supabase/client.js";
+import { requireInternalSecret } from "@/lib/security/require-internal-secret.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request) {
+  const auth = requireInternalSecret(request);
+  if (!auth.ok) return NextResponse.json({ ok: false, error: auth.error || "unauthorized" }, { status: auth.status || 401 });
+  if (!hasSupabaseConfig()) return NextResponse.json({ ok: false, error: "supabase_not_configured" }, { status: 500 });
+  const { data, error } = await supabase.from("send_queue").select("queue_status,type").limit(10000);
+  if (error) throw error;
+  const counts = {};
+  for (const row of data || []) {
+    const status = String(row.queue_status || "unknown").toLowerCase();
+    const type = String(row.type || "outbound").toLowerCase();
+    counts[status] = (counts[status] || 0) + 1;
+    counts[`${type}:${status}`] = (counts[`${type}:${status}`] || 0) + 1;
+  }
+  return NextResponse.json({ ok: true, route: "internal/queue/status", counts });
+}

--- a/src/lib/ai/ai-router.js
+++ b/src/lib/ai/ai-router.js
@@ -1,0 +1,34 @@
+import { normalizeSellerInboundIntent } from "@/lib/domain/seller-flow/resolve-seller-auto-reply-plan.js";
+
+function clean(value) { return String(value ?? "").trim(); }
+function configured(name) { return clean(process.env[name]); }
+
+export function deterministicAiRoute({ use_case = "seller_intent_classification", input = {} } = {}) {
+  const message = input.message || input.message_body || input.text || "";
+  if (use_case === "seller_intent_classification") {
+    const intent = normalizeSellerInboundIntent({ message_body: message, classification: input.classification || {} });
+    return { intent, confidence: 0.72, source: "deterministic", safe_fallback_reply: "Got it — are you open to selling it if the numbers made sense?" };
+  }
+  if (use_case === "reply_quality_check") return { approved: true, risk: "low", source: "deterministic" };
+  if (use_case === "number_verification_scoring") return { score: clean(input.phone).length >= 10 ? 0.7 : 0.2, source: "deterministic" };
+  if (use_case === "offer_generation") return { ok: false, reason: "no_ai_provider_configured", source: "deterministic" };
+  return { ok: true, source: "deterministic" };
+}
+
+export function getAiProviderPriority() {
+  return [
+    configured("OPENCODE_ZEN_API_KEY") || configured("BIG_PICKLE_API_KEY") ? "opencode_zen_big_pickle" : null,
+    configured("GROQ_API_KEY") ? "groq" : null,
+    configured("GEMINI_API_KEY") || configured("GOOGLE_GENERATIVE_AI_API_KEY") ? "gemini" : null,
+    configured("OPENROUTER_API_KEY") ? "openrouter" : null,
+    configured("OLLAMA_BASE_URL") ? "ollama" : null,
+  ].filter(Boolean);
+}
+
+export async function routeAiRequest(payload = {}) {
+  const providers = getAiProviderPriority();
+  if (!providers.length) return { ok: true, provider: "deterministic", result: deterministicAiRoute(payload) };
+  // Provider adapters intentionally stay server-only; until model-specific prompts are configured,
+  // deterministic routing remains the safe non-blocking behavior.
+  return { ok: true, provider: providers[0], provider_configured: true, result: deterministicAiRoute(payload), fallback_used: true };
+}

--- a/src/lib/domain/inbox/enrich-message-event-context.js
+++ b/src/lib/domain/inbox/enrich-message-event-context.js
@@ -1,0 +1,146 @@
+import { normalizePhone } from "@/lib/providers/textgrid.js";
+
+function clean(value) { return String(value ?? "").trim(); }
+function pickFirst(...values) { for (const v of values) { if (v !== null && v !== undefined && clean(v) !== "") return v; } return null; }
+function object(value) { return value && typeof value === "object" && !Array.isArray(value) ? value : {}; }
+function nowIso() { return new Date().toISOString(); }
+function threadKeyFor(from, to, propertyId = null, ownerId = null) {
+  const phones = [normalizePhone(from), normalizePhone(to)].filter(Boolean).sort().join(":");
+  return [clean(propertyId) || clean(ownerId) || "unknown", phones || "no_phone"].join(":");
+}
+
+async function maybeSingle(query) {
+  const { data, error } = await query.maybeSingle();
+  if (error) return null;
+  return data || null;
+}
+
+async function latestFrom(table, supabase, build) {
+  try {
+    return await maybeSingle(build(supabase.from(table).select("*")));
+  } catch { return null; }
+}
+
+function fromQueue(row = {}) {
+  const metadata = object(row.metadata);
+  const snapshot = object(metadata.candidate_snapshot);
+  const seller = object(metadata.seller_identity);
+  const qctx = object(metadata.queue_context);
+  return {
+    property_id: pickFirst(row.property_id, snapshot.property_id, qctx.property_id),
+    master_owner_id: pickFirst(row.master_owner_id, row.owner_id, snapshot.master_owner_id, qctx.master_owner_id),
+    prospect_id: pickFirst(row.prospect_id, snapshot.prospect_id, qctx.prospect_id),
+    textgrid_number_id: pickFirst(row.textgrid_number_id, qctx.textgrid_number_id),
+    template_id: pickFirst(row.template_id, metadata.selected_template_id, metadata.template_id),
+    seller_first_name: pickFirst(row.seller_first_name, metadata.seller_first_name, snapshot.seller_first_name, seller.first_name),
+    seller_display_name: pickFirst(row.seller_display_name, metadata.seller_display_name, snapshot.seller_full_name, snapshot.display_name, seller.display_name),
+    owner_display_name: pickFirst(snapshot.owner_display_name, snapshot.owner_name, row.seller_display_name),
+    owner_type: pickFirst(row.owner_type, snapshot.owner_type),
+    property_address: pickFirst(row.property_address, snapshot.property_address, qctx.property_address),
+    property_city: pickFirst(row.property_city, snapshot.property_city),
+    property_state: pickFirst(row.property_state, snapshot.property_state),
+    property_zip: pickFirst(row.property_zip, snapshot.property_zip),
+    market: pickFirst(row.market, snapshot.market, metadata.market),
+    timezone: pickFirst(row.timezone, snapshot.timezone, metadata.timezone),
+    thread_key: pickFirst(row.thread_key, metadata.thread_key),
+  };
+}
+
+function fromEvent(row = {}) {
+  const metadata = object(row.metadata);
+  const enrichment = object(metadata.enrichment);
+  return {
+    property_id: pickFirst(row.property_id, metadata.property_id, enrichment.property_id),
+    master_owner_id: pickFirst(row.master_owner_id, metadata.master_owner_id, enrichment.master_owner_id),
+    prospect_id: pickFirst(row.prospect_id, metadata.prospect_id),
+    textgrid_number_id: pickFirst(row.textgrid_number_id, metadata.textgrid_number_id),
+    template_id: pickFirst(row.template_id, metadata.template_id),
+    seller_display_name: pickFirst(row.seller_display_name, enrichment.seller_name),
+    owner_display_name: pickFirst(row.owner_display_name, enrichment.seller_name),
+    owner_type: pickFirst(row.owner_type),
+    property_address: pickFirst(row.property_address, enrichment.property_address),
+    market: pickFirst(row.market, enrichment.market),
+    timezone: pickFirst(row.timezone, enrichment.timezone),
+    thread_key: pickFirst(row.thread_key, enrichment.thread_key),
+  };
+}
+
+function merge(...sources) {
+  const out = {};
+  for (const source of sources) for (const [k, v] of Object.entries(source || {})) if (out[k] === undefined || out[k] === null || clean(out[k]) === "") out[k] = v ?? null;
+  return out;
+}
+
+export async function enrichMessageEventContext(eventOrPayload = {}, supabase) {
+  const event = object(eventOrPayload);
+  const metadata = object(event.metadata);
+  const queueId = pickFirst(event.queue_id, event.queue_item_id, event.source_queue_id, metadata.queue_id, metadata.queue_item_id);
+  const providerSid = pickFirst(event.provider_message_sid, event.provider_message_id, event.message_id, metadata.provider_message_id);
+  const from = pickFirst(event.from_phone_number, event.from, metadata.inbound_from);
+  const to = pickFirst(event.to_phone_number, event.to, metadata.inbound_to);
+  const base = fromEvent(event);
+  const sources = [];
+  let source = "event";
+
+  if (queueId) {
+    const row = await latestFrom("send_queue", supabase, (q) => q.eq("id", queueId).order("created_at", { ascending: false }).limit(1));
+    if (row) { sources.push(fromQueue(row)); source = "send_queue.queue_id"; }
+  }
+  if (providerSid) {
+    const row = await latestFrom("send_queue", supabase, (q) => q.or(`provider_message_id.eq.${providerSid},textgrid_message_id.eq.${providerSid}`).order("created_at", { ascending: false }).limit(1));
+    if (row) { sources.push(fromQueue(row)); source = source === "event" ? "send_queue.provider_message" : source; }
+  }
+  if (from && to) {
+    const a = normalizePhone(from); const b = normalizePhone(to);
+    const queueRow = await latestFrom("send_queue", supabase, (q) => q.or(`and(from_phone_number.eq.${a},to_phone_number.eq.${b}),and(from_phone_number.eq.${b},to_phone_number.eq.${a})`).order("created_at", { ascending: false }).limit(1));
+    if (queueRow) { sources.push(fromQueue(queueRow)); source = source === "event" ? "send_queue.phone_pair" : source; }
+    const eventRow = await latestFrom("message_events", supabase, (q) => q.or(`and(from_phone_number.eq.${a},to_phone_number.eq.${b}),and(from_phone_number.eq.${b},to_phone_number.eq.${a})`).order("created_at", { ascending: false }).limit(1));
+    if (eventRow) { sources.push(fromEvent(eventRow)); source = source === "event" ? "message_events.phone_pair" : source; }
+  }
+
+  let enriched = merge(base, ...sources);
+  if (enriched.property_id) {
+    const property = await latestFrom("properties", supabase, (q) => q.eq("id", enriched.property_id).limit(1));
+    if (property) enriched = merge(enriched, { property_address: property.address || property.property_address, property_city: property.city, property_state: property.state, property_zip: property.zip, market: property.market, timezone: property.timezone, latitude: property.latitude, longitude: property.longitude });
+  }
+  if (enriched.master_owner_id) {
+    const owner = await latestFrom("master_owners", supabase, (q) => q.eq("id", enriched.master_owner_id).limit(1));
+    if (owner) enriched = merge(enriched, { seller_display_name: owner.seller_display_name || owner.owner_display_name || owner.name, owner_display_name: owner.owner_display_name || owner.name, owner_type: owner.owner_type });
+  }
+
+  enriched.thread_key = pickFirst(enriched.thread_key, threadKeyFor(from, to, enriched.property_id, enriched.master_owner_id));
+  enriched.enrichment_source = source;
+  enriched.enriched_at = nowIso();
+  enriched.metadata = {
+    ...metadata,
+    enrichment: {
+      ...(object(metadata.enrichment)),
+      source,
+      enriched_at: enriched.enriched_at,
+      thread_key: enriched.thread_key,
+      property_id: enriched.property_id || null,
+      master_owner_id: enriched.master_owner_id || null,
+      seller_name: pickFirst(enriched.seller_display_name, enriched.owner_display_name, enriched.seller_first_name),
+      property_address: enriched.property_address || null,
+      market: enriched.market || null,
+      timezone: enriched.timezone || null,
+    },
+  };
+  return enriched;
+}
+
+export function buildMessageEventEnrichmentUpdate(enrichment = {}) {
+  return {
+    thread_key: enrichment.thread_key || null,
+    property_id: enrichment.property_id || null,
+    master_owner_id: enrichment.master_owner_id || null,
+    prospect_id: enrichment.prospect_id || null,
+    textgrid_number_id: enrichment.textgrid_number_id || null,
+    template_id: enrichment.template_id || null,
+    seller_display_name: enrichment.seller_display_name || enrichment.owner_display_name || null,
+    property_address: enrichment.property_address || null,
+    market: enrichment.market || null,
+    metadata: enrichment.metadata || { enrichment },
+    updated_at: enrichment.enriched_at || nowIso(),
+  };
+}

--- a/src/lib/domain/inbox/keywords.js
+++ b/src/lib/domain/inbox/keywords.js
@@ -1,0 +1,51 @@
+export const KEYWORD_GROUPS = Object.freeze({
+  positive_hot: ["yes", "interested", "maybe", "depends", "i own it", "make offer"],
+  offer_requested: ["how much", "offer", "price", "what price"],
+  opt_out: ["stop", "remove", "unsubscribe"],
+  wrong_number: ["wrong number", "not me", "no soy", "no es mio"],
+  manual_review: ["attorney", "lawyer", "lawsuit", "harassment", "legal"],
+  legal: ["attorney", "lawyer", "lawsuit", "harassment", "legal"],
+});
+
+function clean(value) { return String(value ?? "").trim(); }
+function escapeRegExp(value = "") { return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); }
+
+export function findMatchedKeywords(messageBody = "", groupsOrTerms = []) {
+  const body = clean(messageBody);
+  if (!body) return [];
+  const requested = Array.isArray(groupsOrTerms) ? groupsOrTerms : [groupsOrTerms];
+  const terms = requested.flatMap((entry) => KEYWORD_GROUPS[clean(entry).toLowerCase()] || [entry]).map(clean).filter(Boolean);
+  const seen = new Set();
+  const matches = [];
+  for (const term of terms) {
+    const pattern = term.length <= 3 ? `\\b${escapeRegExp(term)}\\b` : escapeRegExp(term);
+    const rx = new RegExp(pattern, "ig");
+    let match;
+    while ((match = rx.exec(body)) !== null) {
+      const key = `${term.toLowerCase()}:${match.index}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        matches.push({ term, start: match.index, end: match.index + match[0].length });
+      }
+      if (rx.lastIndex === match.index) rx.lastIndex += 1;
+    }
+  }
+  return matches.sort((a, b) => a.start - b.start);
+}
+
+export function classifyInboxMessage(row = {}) {
+  const body = row?.message_body || row?.message_text || "";
+  const positive = findMatchedKeywords(body, ["positive_hot"]);
+  const offer = findMatchedKeywords(body, ["offer_requested"]);
+  const optOut = findMatchedKeywords(body, ["opt_out"]);
+  const wrong = findMatchedKeywords(body, ["wrong_number"]);
+  const legal = findMatchedKeywords(body, ["manual_review"]);
+  return {
+    positive_hot: positive.length > 0,
+    offer_requested: offer.length > 0,
+    opt_out: optOut.length > 0,
+    wrong_number: wrong.length > 0,
+    manual_review: legal.length > 0,
+    matched_keywords: [...positive, ...offer, ...optOut, ...wrong, ...legal].map((m) => m.term),
+  };
+}

--- a/src/lib/domain/inbox/live-inbox-service.js
+++ b/src/lib/domain/inbox/live-inbox-service.js
@@ -1,0 +1,140 @@
+import { supabase as defaultSupabase, hasSupabaseConfig } from "@/lib/supabase/client.js";
+import { classifyInboxMessage, findMatchedKeywords, KEYWORD_GROUPS } from "@/lib/domain/inbox/keywords.js";
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+function clean(value) { return String(value ?? "").trim(); }
+function lower(value) { return clean(value).toLowerCase(); }
+function int(value, fallback) { const n = Number(value); return Number.isFinite(n) && n > 0 ? Math.min(Math.trunc(n), MAX_LIMIT) : fallback; }
+function bool(value) { return ["1", "true", "yes", "on"].includes(lower(value)); }
+function object(value) { return value && typeof value === "object" && !Array.isArray(value) ? value : {}; }
+function asTime(value) { const t = new Date(value || 0).getTime(); return Number.isFinite(t) ? t : 0; }
+function latestAt(row = {}) { return row.latest_activity_at || row.event_timestamp || row.received_at || row.sent_at || row.created_at || row.updated_at || null; }
+function cursorFor(row = {}) { return Buffer.from(JSON.stringify({ t: latestAt(row), id: row.id || row.message_event_key || row.provider_message_sid || "" })).toString("base64url"); }
+function parseCursor(cursor) { try { return JSON.parse(Buffer.from(clean(cursor), "base64url").toString("utf8")); } catch { return null; } }
+function normalizeDirection(value) { const d = lower(value); if (d.startsWith("in")) return "inbound"; if (d.startsWith("out")) return "outbound"; return d || null; }
+function msgId(row) { return row.id || row.message_event_key || row.provider_message_sid || row.provider_message_id || null; }
+function threadKey(row = {}) {
+  const meta = object(row.metadata);
+  const enrichment = object(meta.enrichment);
+  if (row.thread_key || enrichment.thread_key) return row.thread_key || enrichment.thread_key;
+  const phones = [row.from_phone_number, row.to_phone_number].map(clean).filter(Boolean).sort().join(":");
+  return [row.property_id || row.master_owner_id || "unknown", phones || "no_phone"].join(":");
+}
+function displayName(row = {}) { return row.seller_display_name || object(row.metadata)?.enrichment?.seller_name || object(row.metadata)?.seller_display_name || null; }
+
+export function applyInboxRowComputedFields(row = {}, query = {}) {
+  const keywordGroups = [];
+  if (query.keyword_group && KEYWORD_GROUPS[lower(query.keyword_group)]) keywordGroups.push(lower(query.keyword_group));
+  const searchTerms = clean(query.q) ? clean(query.q).split(/\s+/).filter(Boolean) : [];
+  const groupMatches = keywordGroups.length ? findMatchedKeywords(row.message_body || "", keywordGroups) : [];
+  const searchMatches = searchTerms.length ? findMatchedKeywords(row.message_body || "", searchTerms) : [];
+  const flags = classifyInboxMessage(row);
+  return {
+    ...row,
+    id: msgId(row),
+    direction: normalizeDirection(row.direction),
+    thread_key: threadKey(row),
+    latest_activity_at: latestAt(row),
+    seller_display_name: displayName(row),
+    property_address: row.property_address || object(row.metadata)?.enrichment?.property_address || null,
+    market: row.market || object(row.metadata)?.enrichment?.market || null,
+    flags,
+    matched_keywords: [...new Set([...flags.matched_keywords, ...groupMatches.map((m) => m.term), ...searchMatches.map((m) => m.term)])],
+    highlight_ranges: [...groupMatches, ...searchMatches].map(({ start, end, term }) => ({ start, end, term })),
+  };
+}
+
+function rowMatchesFilter(row = {}, filter = "all") {
+  const f = lower(filter) || "all";
+  const dir = normalizeDirection(row.direction);
+  const flags = row.flags || classifyInboxMessage(row);
+  const ar = lower(row.auto_reply_status || object(row.metadata).auto_reply_status);
+  if (f === "all") return true;
+  if (f === "inbound_only") return dir === "inbound";
+  if (f === "outbound_only") return dir === "outbound";
+  if (f === "needs_reply") return dir === "inbound" && !["queued", "sent", "suppressed"].includes(ar);
+  if (f === "auto_replied") return ["queued", "sent", "delivered"].includes(ar);
+  if (f === "auto_reply_failed") return ["failed", "error"].includes(ar);
+  if (f === "positive_hot") return flags.positive_hot;
+  if (f === "offer_requested") return flags.offer_requested;
+  if (f === "wrong_number") return flags.wrong_number;
+  if (f === "opt_out") return flags.opt_out;
+  if (f === "missing_context") return !row.property_id && !row.master_owner_id && !object(row.metadata)?.enrichment?.property_id;
+  if (f === "manual_review") return flags.manual_review || ar === "manual_review";
+  return true;
+}
+
+function buildThreads(messages = []) {
+  const byThread = new Map();
+  for (const message of messages) {
+    const key = message.thread_key;
+    const existing = byThread.get(key) || { thread_key: key, messages: [], message_count: 0 };
+    existing.messages.push(message.id);
+    existing.message_count += 1;
+    if (!existing.latest_activity_at || asTime(message.latest_activity_at) > asTime(existing.latest_activity_at)) {
+      Object.assign(existing, {
+        latest_activity_at: message.latest_activity_at,
+        latest_message_direction: message.direction,
+        latest_message_body: message.message_body || null,
+        property_id: message.property_id || existing.property_id || null,
+        master_owner_id: message.master_owner_id || existing.master_owner_id || null,
+        seller_display_name: message.seller_display_name || existing.seller_display_name || null,
+        property_address: message.property_address || existing.property_address || null,
+        market: message.market || existing.market || null,
+        needs_reply: rowMatchesFilter(message, "needs_reply"),
+        positive_hot: Boolean(message.flags?.positive_hot || existing.positive_hot),
+        auto_reply_status: message.auto_reply_status || existing.auto_reply_status || null,
+      });
+    }
+    byThread.set(key, existing);
+  }
+  return [...byThread.values()].sort((a, b) => asTime(b.latest_activity_at) - asTime(a.latest_activity_at));
+}
+
+function buildCounts(rows = []) {
+  const counts = { all: rows.length, inbound_only: 0, outbound_only: 0, needs_reply: 0, auto_replied: 0, auto_reply_failed: 0, positive_hot: 0, offer_requested: 0, wrong_number: 0, opt_out: 0, missing_context: 0, manual_review: 0 };
+  for (const row of rows) for (const key of Object.keys(counts)) if (key !== "all" && rowMatchesFilter(row, key)) counts[key] += 1;
+  return counts;
+}
+
+async function loadMapPins(supabase, query, filteredRows = []) {
+  const filteredPropertyIds = [...new Set(filteredRows.map((r) => r.property_id).filter(Boolean))];
+  let q = supabase.from("properties").select("id,property_id,latitude,longitude,address,property_address,market,lead_status,stage,seller_name,master_owner_id").not("latitude", "is", null).not("longitude", "is", null).limit(10000);
+  if (bool(query.filtered_pins) && filteredPropertyIds.length) q = q.in("id", filteredPropertyIds);
+  const { data, error } = await q;
+  if (error) return [];
+  const latestByProperty = new Map();
+  for (const row of filteredRows) if (row.property_id && (!latestByProperty.has(String(row.property_id)) || asTime(row.latest_activity_at) > asTime(latestByProperty.get(String(row.property_id)).latest_activity_at))) latestByProperty.set(String(row.property_id), row);
+  return (Array.isArray(data) ? data : []).map((p) => {
+    const id = p.id || p.property_id;
+    const latest = latestByProperty.get(String(id)) || {};
+    return { property_id: id, thread_key: latest.thread_key || null, latitude: Number(p.latitude), longitude: Number(p.longitude), address: p.address || p.property_address, market: p.market || latest.market || null, seller_name: p.seller_name || latest.seller_display_name || null, lead_status: p.lead_status || p.stage || null, stage: p.stage || latest.stage_after || latest.stage_before || null, latest_message_direction: latest.direction || null, latest_message_at: latest.latest_activity_at || null, needs_reply: latest.id ? rowMatchesFilter(latest, "needs_reply") : false, positive_hot: Boolean(latest.flags?.positive_hot), auto_reply_status: latest.auto_reply_status || null };
+  });
+}
+
+export async function getLiveInbox(params = {}, deps = {}) {
+  if (!deps.supabase && !hasSupabaseConfig()) throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  const supabase = deps.supabase || defaultSupabase;
+  const limit = int(params.limit, DEFAULT_LIMIT);
+  const direction = lower(params.direction || "all");
+  const cursor = parseCursor(params.cursor);
+  const wantsMap = bool(params.map);
+  let scanLimit = Math.max(limit * 4, 500);
+  if (params.filter && params.filter !== "all") scanLimit = Math.max(scanLimit, 2000);
+
+  let q = supabase.from("message_events").select("*").order("created_at", { ascending: false }).limit(scanLimit);
+  if (direction === "inbound" || direction === "outbound") q = q.eq("direction", direction);
+  if (cursor?.t) q = q.lt("created_at", cursor.t);
+  if (clean(params.q)) q = q.ilike("message_body", `%${clean(params.q)}%`);
+  const { data, error } = await q;
+  if (error) throw error;
+  let rows = (Array.isArray(data) ? data : []).map((row) => applyInboxRowComputedFields(row, params));
+  if (params.keyword_group) rows = rows.filter((row) => findMatchedKeywords(row.message_body || "", [params.keyword_group]).length > 0);
+  rows = rows.filter((row) => rowMatchesFilter(row, params.filter || "all"));
+  rows.sort((a, b) => asTime(b.latest_activity_at) - asTime(a.latest_activity_at));
+  const pageRows = rows.slice(0, limit);
+  const mapPins = wantsMap ? await loadMapPins(supabase, params, rows) : [];
+  return { threads: buildThreads(pageRows), messages: pageRows, counts: buildCounts(rows), mapPins, pagination: { limit, returned: pageRows.length, has_more: rows.length > limit || (Array.isArray(data) && data.length === scanLimit), next_cursor: pageRows.length ? cursorFor(pageRows[pageRows.length - 1]) : null } };
+}

--- a/src/lib/domain/queue/is-manual-inbox-send.js
+++ b/src/lib/domain/queue/is-manual-inbox-send.js
@@ -54,7 +54,10 @@ export function isUnknownAutoReply(queue_item = null) {
   const source = lower(metadataValue(queue_item, "source"));
   const unknown_inbound = metadataValue(queue_item, "unknown_inbound") === true;
 
+  const type = lower(queue_item?.type || metadataValue(queue_item, "type"));
+
   return (
+    type === "auto_reply" ||
     use_case_template === "unknown_inbound_auto_reply" ||
     message_type === "unknown inbound auto reply" ||
     source === "textgrid_inbound_unknown_router" ||

--- a/src/lib/domain/queue/run-send-queue.js
+++ b/src/lib/domain/queue/run-send-queue.js
@@ -448,9 +448,13 @@ export async function runSendQueue(
       return { ok: false, status: 423, ...buildDisabledResponse("queue_runner_enabled", "runSendQueue"), skipped: true, reason: "system_control_disabled", sent_count: 0, results: [] };
     }
     const outbound_sms_enabled = await get_system_flag("outbound_sms_enabled");
-    if (!outbound_sms_enabled) {
-      info("queue_runner.blocked", { flag: "outbound_sms_enabled" });
+    const auto_reply_live_enabled = await get_system_flag("auto_reply_live_enabled");
+    if (!outbound_sms_enabled && !auto_reply_live_enabled) {
+      info("queue_runner.blocked", { flag: "outbound_sms_enabled", auto_reply_live_enabled });
       return { ok: false, status: 423, ...buildDisabledResponse("outbound_sms_enabled", "runSendQueue"), skipped: true, reason: "system_control_disabled", sent_count: 0, results: [] };
+    }
+    if (!outbound_sms_enabled && auto_reply_live_enabled) {
+      deps = { ...deps, queue_types: ["auto_reply"], outbound_sms_enabled: false, auto_reply_live_enabled: true };
     }
   }
 
@@ -591,6 +595,9 @@ export async function runSendQueue(
         ...deps,
         dry_run,
       });
+      if (deps.outbound_sms_enabled === false && deps.auto_reply_live_enabled === true) {
+        candidate_summary.rows = normalizeRows(candidate_summary.rows).filter((row) => lower(row?.type || row?.metadata?.type) === "auto_reply");
+      }
       const dedupe_result = dedupeRowsByOwnerPhoneTouch(
         candidate_summary.rows
       );

--- a/src/lib/domain/seller-flow/maybe-queue-seller-stage-reply.js
+++ b/src/lib/domain/seller-flow/maybe-queue-seller-stage-reply.js
@@ -340,6 +340,8 @@ export async function maybeQueueSellerStageReply({
         smart_cash_offer_display: plan.offer_price_display,
         ...(extra_template_render_overrides || {}),
       },
+      rendered_message_text: plan.fallback_reply || null,
+      message_text: plan.fallback_reply || null,
       extra_queue_context: {
         ...(extra_queue_context || {}),
         // Auto-reply fields
@@ -351,6 +353,10 @@ export async function maybeQueueSellerStageReply({
         source_event_id: extra_queue_context?.source_event_id || null,
         inbound_message_id: inbound_from || null,
         thread_key: context?.ids?.thread_key || null,
+        from_phone_number: context?.summary?.inbound_to || context?.summary?.textgrid_number || null,
+        sms_eligible: true,
+        routing_allowed: true,
+        safety_status: "allowed",
         owner_id: context?.ids?.master_owner_id || null,
         market: context?.summary?.market || context?.summary?.market_name || null,
       },

--- a/src/lib/domain/seller-flow/resolve-seller-auto-reply-plan.js
+++ b/src/lib/domain/seller-flow/resolve-seller-auto-reply-plan.js
@@ -259,6 +259,7 @@ export async function resolveSellerAutoReplyPlan(input = {}) {
   let should_queue_reply = !suppression.suppress;
   let suppression_reason = suppression.reason;
   let reply_mode = suppression.suppress ? "suppress" : "auto_queue";
+  let fallback_reply = null;
   
   let is_duplicate = false;
   if (should_queue_reply) {
@@ -292,20 +293,17 @@ export async function resolveSellerAutoReplyPlan(input = {}) {
             });
 
         if (!fallbackTemplate) {
-          should_queue_reply = false;
-          suppression_reason = "template_not_found_for_auto_reply_plan";
-          reply_mode = "suppress";
+          fallback_reply = "Got it — are you open to selling it if the numbers made sense?";
+          reply_mode = "auto_queue_fallback";
         }
       } else if (!template) {
-        should_queue_reply = false;
-        suppression_reason = "template_not_found_for_auto_reply_plan";
-        reply_mode = "suppress";
+        fallback_reply = "Got it — are you open to selling it if the numbers made sense?";
+        reply_mode = "auto_queue_fallback";
       }
     } catch (e) {
       warn("auto_reply_plan.template_check_failed", { error: e.message });
-      should_queue_reply = false;
-      suppression_reason = "template_not_found_for_auto_reply_plan";
-      reply_mode = "suppress";
+      fallback_reply = "Got it — are you open to selling it if the numbers made sense?";
+      reply_mode = "auto_queue_fallback";
     }
   }
   
@@ -327,6 +325,7 @@ export async function resolveSellerAutoReplyPlan(input = {}) {
     selected_use_case,
     selected_stage_code,
     selected_language,
+    fallback_reply,
     priority,
     reply_mode,
     reason: suppression_reason || "plan_resolved",

--- a/src/lib/supabase/sms-engine.js
+++ b/src/lib/supabase/sms-engine.js
@@ -10,6 +10,7 @@ import { captureSystemEvent } from "@/lib/analytics/posthog-server.js";
 import { sendCriticalAlert } from "@/lib/alerts/discord.js";
 import { info, warn } from "@/lib/logging/logger.js";
 import { isManualInboxSend, isUnknownAutoReply } from "@/lib/domain/queue/is-manual-inbox-send.js";
+import { enrichMessageEventContext, buildMessageEventEnrichmentUpdate } from "@/lib/domain/inbox/enrich-message-event-context.js";
 
 const SEND_QUEUE_TABLE = "send_queue";
 const MESSAGE_EVENTS_TABLE = "message_events";
@@ -240,6 +241,22 @@ export function normalizeSendQueueRow(row) {
     delivery_confirmed: safe_row.delivery_confirmed || null,
     // Offer record sync tracking (added 2026-04-22)
     cash_offer_snapshot_id:    safe_row.cash_offer_snapshot_id    || null,
+    type: safe_row.type || null,
+    thread_key: safe_row.thread_key || safe_row.metadata?.thread_key || null,
+    owner_id: safe_row.owner_id || null,
+    agent_id: safe_row.agent_id || null,
+    template_source: safe_row.template_source || null,
+    rendered_message: safe_row.rendered_message || null,
+    sms_eligible: safe_row.sms_eligible,
+    routing_allowed: safe_row.routing_allowed,
+    safety_status: safe_row.safety_status || null,
+    source_event_id: safe_row.source_event_id || null,
+    inbound_message_id: safe_row.inbound_message_id || null,
+    detected_intent: safe_row.detected_intent || null,
+    stage_before: safe_row.stage_before || null,
+    stage_after: safe_row.stage_after || null,
+    textgrid_message_id: safe_row.textgrid_message_id || null,
+    market: safe_row.market || null,
     offer_podio_item_id:       safe_row.offer_podio_item_id       || null,
     offer_record_sync_status:  safe_row.offer_record_sync_status  || null,
     offer_record_sync_error:   safe_row.offer_record_sync_error   || null,
@@ -472,12 +489,18 @@ export async function loadRunnableSendQueueRows(limit = 50, deps = {}) {
     }
   }
 
-  const { data, error } = await supabase
+  let query = supabase
     .from(SEND_QUEUE_TABLE)
     .select("*")
     .or(`queue_status.eq.queued,queue_status.eq.ready,queue_status.eq.scheduled`)
     .or(`scheduled_for.is.null,scheduled_for.lte.${now}`)
-    .not("is_locked", "is", "true")
+    .not("is_locked", "is", "true");
+
+  if (Array.isArray(deps.queue_types) && deps.queue_types.length) {
+    query = query.in("type", deps.queue_types);
+  }
+
+  const { data, error } = await query
     .order("send_priority", { ascending: false, nullsFirst: false })
     .order("scheduled_for", { ascending: true, nullsFirst: true })
     .limit(preclaim_scan_limit);
@@ -1055,12 +1078,26 @@ function buildSuccessMessageEvent(row, send_result, options = {}) {
     textgrid_number_id: normalized.textgrid_number_id,
     template_id: normalized.template_id,
     property_address: normalized.property_address,
-    stage_before: normalized.current_stage || null,
-    stage_after: normalized.current_stage || null,
+    market: normalized.market || null,
+    thread_key: normalized.thread_key || null,
+    auto_reply_status: normalized.type === "auto_reply" ? "sent" : null,
+    auto_reply_queue_id: normalized.type === "auto_reply" ? String(normalized.id || "") : null,
+    detected_intent: normalized.detected_intent || null,
+    stage_before: normalized.stage_before || normalized.current_stage || null,
+    stage_after: normalized.stage_after || normalized.current_stage || null,
     metadata: {
       source: "supabase_send_queue",
       queue_key,
       send_result,
+      enrichment: {
+        thread_key: normalized.thread_key || null,
+        property_id: normalized.property_id || null,
+        master_owner_id: normalized.master_owner_id || null,
+        seller_name: normalized.seller_display_name || normalized.seller_first_name || null,
+        property_address: normalized.property_address || null,
+        market: normalized.market || null,
+        timezone: normalized.timezone || null,
+      },
       queue_row: {
         id: normalized.id,
         queue_key: normalized.queue_key,
@@ -1842,7 +1879,7 @@ export async function logInboundMessageEvent(payload, options = {}) {
     }));
   }
 
-  const event = {
+  let event = {
     message_event_key: `inbound_${message_sid || crypto.randomUUID()}`,
     provider_message_sid: message_sid || null,
     direction: "inbound",
@@ -1865,6 +1902,13 @@ export async function logInboundMessageEvent(payload, options = {}) {
       payload,
     },
   };
+
+  try {
+    const enrichment = await enrichMessageEventContext(event, getSupabase(options));
+    event = { ...event, ...buildMessageEventEnrichmentUpdate(enrichment) };
+  } catch (_) {
+    event.metadata = { ...event.metadata, enrichment: { source: "inbound_enrichment_failed", enriched_at: now } };
+  }
 
   // Analytics fires regardless of DI injection path — the inbound message
   // payload is already validated at this point.
@@ -1909,6 +1953,7 @@ export async function syncDeliveryEvent(payload, options = {}) {
     provider_delivery_status: provider_status || null,
     raw_carrier_status: raw_carrier_status || null,
     delivery_status,
+    updated_at: now,
   };
 
   if (provider_status === "delivered") {

--- a/supabase/migrations/20260506_finalize_supabase_inbox_auto_replies_map.sql
+++ b/supabase/migrations/20260506_finalize_supabase_inbox_auto_replies_map.sql
@@ -1,0 +1,39 @@
+-- Finalize Supabase-first inbox, enrichment, auto-replies, queue automation, and map support.
+
+alter table if exists public.message_events
+  add column if not exists updated_at timestamptz default now(),
+  add column if not exists thread_key text,
+  add column if not exists seller_display_name text,
+  add column if not exists property_address text,
+  add column if not exists market text,
+  add column if not exists auto_reply_status text,
+  add column if not exists auto_reply_queue_id text,
+  add column if not exists detected_intent text,
+  add column if not exists metadata jsonb default '{}'::jsonb;
+
+alter table if exists public.message_events
+  alter column metadata set default '{}'::jsonb;
+
+create index if not exists idx_message_events_created_at_desc on public.message_events (created_at desc);
+create index if not exists idx_message_events_direction_created_at_desc on public.message_events (direction, created_at desc);
+create index if not exists idx_message_events_thread_key on public.message_events (thread_key);
+create index if not exists idx_message_events_phone_pair_created_at_desc on public.message_events (from_phone_number, to_phone_number, created_at desc);
+create index if not exists idx_message_events_property_id on public.message_events (property_id);
+create index if not exists idx_message_events_master_owner_id on public.message_events (master_owner_id);
+
+alter table if exists public.send_queue
+  add column if not exists type text,
+  add column if not exists thread_key text,
+  add column if not exists seller_first_name text,
+  add column if not exists seller_display_name text,
+  add column if not exists market text,
+  add column if not exists timezone text,
+  add column if not exists textgrid_message_id text,
+  add column if not exists template_source text,
+  add column if not exists rendered_message text;
+
+create index if not exists idx_send_queue_status_type_created_at_desc on public.send_queue (queue_status, type, created_at desc);
+create index if not exists idx_send_queue_phone_pair_created_at_desc on public.send_queue (from_phone_number, to_phone_number, created_at desc);
+create index if not exists idx_send_queue_thread_key on public.send_queue (thread_key);
+create index if not exists idx_send_queue_provider_message_id on public.send_queue (provider_message_id);
+create index if not exists idx_send_queue_textgrid_message_id on public.send_queue (textgrid_message_id);

--- a/tests/critical/dashboard-ops-service.test.mjs
+++ b/tests/critical/dashboard-ops-service.test.mjs
@@ -105,3 +105,59 @@ test("getOpsFeederSnapshot rejects legacy feeder requests unless env flag is tru
     }
   }
 });
+test('live inbox exposes cursor pagination, filters, keyword matches, and map pins', async () => {
+  const { getLiveInbox } = await import('@/lib/domain/inbox/live-inbox-service.js');
+  const rows = Array.from({ length: 260 }, (_, idx) => ({
+    id: idx + 1,
+    created_at: new Date(Date.UTC(2026, 4, 6, 12, 0, 0) - idx * 1000).toISOString(),
+    direction: idx % 3 === 0 ? 'inbound' : 'outbound',
+    message_body: idx === 0 ? 'yes I am interested, make offer' : idx === 3 ? 'how much is your offer' : `message ${idx}`,
+    from_phone_number: '+15550000001',
+    to_phone_number: '+15550000002',
+    property_id: idx < 10 ? 101 : null,
+    master_owner_id: 201,
+    seller_display_name: 'Test Seller',
+    property_address: '123 Main St',
+    market: 'Test Market',
+    metadata: {},
+  }));
+  const supabase = {
+    from(table) {
+      const state = { table, limit: 1000, direction: null, q: null };
+      const api = {
+        select() { return api; },
+        order() { return api; },
+        limit(n) { state.limit = n; return api; },
+        eq(col, val) { if (col === 'direction') state.direction = val; return api; },
+        lt() { return api; },
+        ilike(_col, val) { state.q = String(val).replaceAll('%', '').toLowerCase(); return api; },
+        not() { return api; },
+        then(resolve) {
+          if (state.table === 'properties') return resolve({ data: [{ id: 101, latitude: 34.1, longitude: -118.2, address: '123 Main St', market: 'Test Market', seller_name: 'Test Seller', stage: 'new' }], error: null });
+          let data = rows;
+          if (state.direction) data = data.filter((r) => r.direction === state.direction);
+          if (state.q) data = data.filter((r) => r.message_body.toLowerCase().includes(state.q));
+          return resolve({ data: data.slice(0, state.limit), error: null });
+        },
+      };
+      return api;
+    },
+  };
+  const page = await getLiveInbox({ limit: '100', direction: 'all', map: 'true' }, { supabase });
+  assert.strictEqual(page.messages.length, 100);
+  assert.ok(page.pagination.has_more);
+  assert.ok(page.pagination.next_cursor);
+  assert.ok(page.mapPins.length >= 1);
+
+  const inbound = await getLiveInbox({ limit: '100', direction: 'inbound' }, { supabase });
+  assert.ok(inbound.messages.every((m) => m.direction === 'inbound'));
+
+  const keyword = await getLiveInbox({ limit: '10', q: 'interested' }, { supabase });
+  assert.ok(keyword.messages[0].matched_keywords.includes('interested'));
+
+  const hot = await getLiveInbox({ limit: '10', filter: 'positive_hot' }, { supabase });
+  assert.ok(hot.messages.some((m) => m.flags.positive_hot));
+
+  const needsReply = await getLiveInbox({ limit: '10', filter: 'needs_reply' }, { supabase });
+  assert.ok(needsReply.messages.every((m) => m.direction === 'inbound'));
+});

--- a/tests/critical/seller-auto-reply-plan.test.mjs
+++ b/tests/critical/seller-auto-reply-plan.test.mjs
@@ -110,3 +110,22 @@ describe("Seller Auto Reply Plan", () => {
     assert.ok(res.next_stage === "unclear_clarifier" || res.next_stage === "manual_review");
   });
 });
+
+test('auto reply plan uses safe fallback reply when template lookup is missing', async () => {
+  const { resolveSellerAutoReplyPlan } = await import('@/lib/domain/seller-flow/resolve-seller-auto-reply-plan.js');
+  const priorNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production';
+  try {
+    const plan = await resolveSellerAutoReplyPlan({
+      message_body: 'yes',
+      auto_reply_enabled: true,
+      force_queue_reply: true,
+      conversation_context: { found: true, summary: { conversation_stage: 'ownership_check' } },
+      classification: {},
+    });
+    assert.strictEqual(plan.should_queue_reply, true);
+    assert.strictEqual(plan.fallback_reply, 'Got it — are you open to selling it if the numbers made sense?');
+  } finally {
+    process.env.NODE_ENV = priorNodeEnv;
+  }
+});

--- a/tests/critical/supabase-queue.test.mjs
+++ b/tests/critical/supabase-queue.test.mjs
@@ -364,3 +364,8 @@ describe("Delivery webhook updates status", () => {
     assert.strictEqual(result.delivery_status, "failed");
   });
 });
+
+it('auto_reply queue rows are classified as unknown auto replies for cold-outbound pause exemption', async () => {
+  const { isUnknownAutoReply } = await import('@/lib/domain/queue/is-manual-inbox-send.js');
+  assert.strictEqual(isUnknownAutoReply({ type: 'auto_reply', message_body: 'Got it' }), true);
+});


### PR DESCRIPTION
### Motivation
- Make Supabase the real-time operational source for inbox/messages, auto-replies, queue automation, enrichment, and map pins so inbound handling does not depend on Podio and replies are reliable.
- Ensure auto-replies are safe and can be processed even when cold outbound is paused, and provide deterministic AI fallback when no provider is configured.
- Surface a clean dashboard API for inbox threads, filters, counts, cursor-pagination and map pins for the frontend.

### Description
- Added a Supabase-first live inbox API at `GET /api/internal/dashboard/inbox/live` that returns cursor pagination, threads, messages, counts, highlight ranges, matched keywords, and `mapPins` (supports filtering and keyword_group). (new: `src/app/api/internal/dashboard/inbox/live/route.js`, `src/lib/domain/inbox/live-inbox-service.js`, `src/lib/domain/inbox/keywords.js`)
- Implemented `enrichMessageEventContext(eventOrPayload, supabase)` to resolve context from send_queue/message_events/properties/master_owners (multiple lookup strategies) and wrote enrichment into `metadata.enrichment`, and wired it into inbound logging and outbound success events. (new: `src/lib/domain/inbox/enrich-message-event-context.js`, changes in `src/lib/supabase/sms-engine.js`)
- Hardened auto-reply plan and queue pipeline so missing templates do not block eligible auto-replies by providing a safe fallback reply and storing auto-reply metadata on queued rows; added ability to queue/send `type=auto_reply` while cold outbound is paused by gating runner logic on `auto_reply_live_enabled`. (changes: `src/lib/domain/seller-flow/resolve-seller-auto-reply-plan.js`, `src/lib/domain/seller-flow/maybe-queue-seller-stage-reply.js`, `src/lib/domain/queue/run-send-queue.js`, `src/lib/domain/queue/is-manual-inbox-send.js`)
- Added server-only AI router with provider-priority detection and deterministic fallback behavior at `POST /api/internal/ai-router`. (new: `src/lib/ai/ai-router.js`, `src/app/api/internal/ai-router/route.js`)
- Added queue status counts endpoint `GET /api/internal/queue/status` and a safe Supabase migration to add missing inbox/queue fields and indexes. (new: `src/app/api/internal/queue/status/route.js`, `supabase/migrations/20260506_finalize_supabase_inbox_auto_replies_map.sql`)
- Updated send_queue/ message_events Supabase integrations to include thread keys, auto-reply status/ids, detected intent, enrichment payloads, and an `updated_at` on delivery payloads to fix delivery reconcile issues. (changes in `src/lib/supabase/sms-engine.js`)

### Testing
- Ran the proof suites and they passed: `npm run proof:inbox`, `npm run proof:auto-replies`, `npm run proof:supabase-queue`, and `npm run proof:queue` all completed successfully (all proof tests passed).
- Built the app with required test env vars and the production build completed successfully when run with test Podio envs: `PODIO_CLIENT_ID=test PODIO_CLIENT_SECRET=test PODIO_USERNAME=test PODIO_PASSWORD=test INTERNAL_API_SECRET=test BUYER_WEBHOOK_SECRET=test OPS_DASHBOARD_SECRET=test APP_BASE_URL=http://localhost:3000 npm run build` succeeded; note that a plain `npm run build` in this environment fails without Podio credentials during Next page-data collection.
- Verified unit/behavioral additions: live inbox pagination/filter/search/map behavior, auto-reply fallback behavior, and auto_reply queue classification are covered by new/updated tests under `tests/critical/` and passed in the proof runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa84cc8b8c8331a5bc0c8a5ab07131)